### PR TITLE
GasCap adjusting indentation

### DIFF
--- a/GasCap/AssetTracker_GasCap_v.02e/AssetTracker_GasCap_v.02e.ino
+++ b/GasCap/AssetTracker_GasCap_v.02e/AssetTracker_GasCap_v.02e.ino
@@ -55,7 +55,6 @@ float VDDA, VBAT, VBUS, STM32L0Temp;
 uint32_t UID[3] = {0, 0, 0};
 char buffer[32];
 
-
 // LIS2DW12 definitions
 #define LIS2DW12_intPin1 3  // interrupt1 pin definitions, wake interrupt pin
 #define LIS2DW12_intPin2 A4 // interrupt2 pin definitions, sleep interrupt pin
@@ -86,7 +85,6 @@ bool InMotion = false;
 
 LIS2DW12 LIS2DW12(&i2c_0); // instantiate LIS2DW12 class
 
-
 // BME280 definitions
 /* Specify BME280 configuration
  *  Choices are:
@@ -104,7 +102,6 @@ uint32_t compHumidity, compPress;                                 // variables t
 float temperature_C, temperature_F, pressure, humidity, altitude; // Scaled output of the BME280
 
 BME280 BME280(&i2c_0); // instantiate BME280 class
-
 
 // CAM M8Q GNSS configuration
 #define GNSS_en 5      // enable for GNSS 3.0 V LDO
@@ -143,7 +140,6 @@ static const char *fixQualityString[] = {
     "/SIMULATION",
 };
 
-
 // SPI Flash: 64 MBit (8 MByte) SPI Flash 32,768, 256-byte pages
 #define csPin 25 // SPI Flash chip select pin
 
@@ -155,10 +151,10 @@ volatile bool logData = false;
 
 SPIFlash SPIFlash(csPin);
 
-
-void setup()
+void setup() 
 {
-  if (SerialDebug) {
+  if (SerialDebug) 
+  {
     Serial.begin(115200);
     Serial.println("Serial enabled!");
     delay(5000);
@@ -206,14 +202,16 @@ void setup()
 
   // Read the LIS2DW12 Chip ID register, this is a good test of communication
   byte LIS2DW12_ChipID = LIS2DW12.getChipID();  // Read CHIP_ID register for LIS2DW12
-  if(SerialDebug) {
+  if(SerialDebug)
+  {
     Serial.print("LIS2DW12 "); Serial.print("I AM "); Serial.print(LIS2DW12_ChipID, HEX); Serial.print(" I should be "); Serial.println(0x44, HEX);
     Serial.println(" ");
   }
 
   // Read the WHO_AM_I register of the BME280 this is a good test of communication
   byte BME280_ChipID = BME280.getChipID();  // Read WHO_AM_I register for BME280
-  if(SerialDebug) {
+  if(SerialDebug)
+  {
   Serial.print("BME280 "); Serial.print("I AM "); Serial.print(BME280_ChipID, HEX); Serial.print(" I should be "); Serial.println(0x60, HEX);
   Serial.println(" ");
   }
@@ -228,7 +226,8 @@ void setup()
     delay(100);
 
    LIS2DW12.selfTest(stress); // perform sensor self test
-   if(SerialDebug) {
+   if(SerialDebug)
+   {
     Serial.print("x-axis self test = "); Serial.print(stress[0], 1); Serial.println("mg, should be between 70 and 1500 mg");
     Serial.print("y-axis self test = "); Serial.print(stress[1], 1); Serial.println("mg, should be between 70 and 1500 mg");
     Serial.print("z-axis self test = "); Serial.print(stress[2], 1); Serial.println("mg, should be between 70 and 1500 mg");
@@ -239,10 +238,11 @@ void setup()
 
     aRes = 0.000244f * (1 << fs); // scale resolutions per LSB for the sensor at 14-bit data
 
-   if(SerialDebug) Serial.println("hold flat and motionless for bias calibration");
+    if (SerialDebug) Serial.println("hold flat and motionless for bias calibration");
     delay(5000);
     LIS2DW12.Compensation(fs, odr, mode, lpMode, bw, lowNoise, offset); // quickly estimate offset bias in normal mode
-   if(SerialDebug) {
+   if(SerialDebug)
+   {
     Serial.print("x-axis offset = "); Serial.print(offset[0]*1000.0f, 1); Serial.println(" mg");
     Serial.print("y-axis offset = "); Serial.print(offset[1]*1000.0f, 1); Serial.println(" mg");
     Serial.print("z-axis offset = "); Serial.print(offset[2]*1000.0f, 1); Serial.println(" mg");
@@ -258,12 +258,12 @@ void setup()
 
     BME280.init(Posr, Hosr, Tosr, Mode, IIRFilter, SBy); // Initialize BME280 altimeter
     BME280.forced();                                     // get initial data sample, then go back to sleep
- 
   }
-  else 
-  {
-   if(LIS2DW12_ChipID != 0x44 && SerialDebug) Serial.println(" LIS2DW12 not functioning!");
-   if(BME280_ChipID != 0x60 && SerialDebug) Serial.println(" BME280 not functioning!");
+  else {
+    if (LIS2DW12_ChipID != 0x44 && SerialDebug)
+      Serial.println(" LIS2DW12 not functioning!");
+    if (BME280_ChipID != 0x60 && SerialDebug)
+      Serial.println(" BME280 not functioning!");
   }
 
   pinMode(csPin, OUTPUT); // set SPI chip select as L082 output
@@ -273,13 +273,15 @@ void setup()
   SPIFlash.init();              // start SPI
   SPIFlash.powerUp();           // MX25R6435FZAI defaults to power down state
   SPIFlash.getChipID(flash_id); // Verify SPI flash communication
-  if (flash_id[0] == 0xC2 && flash_id[1] == 0x28 && flash_id[2] == 0x17 && SerialDebug) {
+  if (flash_id[0] == 0xC2 && flash_id[1] == 0x28 && flash_id[2] == 0x17 && SerialDebug)
+  {
     Serial.println(" ");
     Serial.println("Found Macronix MX25R6435FZAI with Chip ID = 0xC2, 0x28, 0x17!");
     Serial.println(" ");
   }
   else {
-    if (SerialDebug) {
+    if (SerialDebug)
+    {
       Serial.println(" ");
       Serial.println("no or unknown SPI flash!");
       Serial.println(" ");
@@ -306,7 +308,8 @@ void setup()
   STM32L0Temp = STM32L0.getTemperature();
 
   // Internal STM32L0 functions
-  if (SerialDebug) {
+  if (SerialDebug)
+  {
     Serial.print("VDDA = "); Serial.print(VDDA, 2); Serial.println(" V");
     Serial.print("VBAT = "); Serial.print(VBAT, 2); Serial.println(" V");
     if(VBUS ==  1)  Serial.println("USB Connected!"); 
@@ -349,7 +352,6 @@ void setup()
   LIS2DW12.getStatus(); // read status of interrupts to clear
 } /* end of setup */
 
-
 /*
  * Everything in the main loop is based on interrupts, so that
  * if there has not been an interrupt event the STM32L082 should be in STOP mode
@@ -358,44 +360,44 @@ void setup()
 void loop()
 {
   /* LIS2DW12 wake detect*/
-  if(LIS2DW12_wake_flag)
+  if (LIS2DW12_wake_flag)
   {
     LIS2DW12_wake_flag = false; // clear the wake flag if wake event
 
     InMotion = true; // set motion state latch
-   if(SerialDebug) Serial.println("** LIS2DW12 is awake! **");
+    if (SerialDebug)
+      Serial.println("** LIS2DW12 is awake! **");
 
     LIS2DW12.activateNoMotionInterrupt();
     attachInterrupt(LIS2DW12_intPin2, myinthandler2, RISING); // attach no-motion interrupt for INT2 pin output of LIS2DW12
 
-   digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH);  // toggle blue led when motion detected      
+    digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // toggle blue led when motion detected
   }                            /* end of LIS2DW12 wake detect */
 
-  
   /* LIS2DW12 sleep detect*/ // Not needed for basic wake/GNSS on motion case
-  if(LIS2DW12_sleep_flag)
+  if (LIS2DW12_sleep_flag)
   {
     LIS2DW12_sleep_flag = false; // clear the sleep flag
     InMotion = false;            // set motion state latch
-   if(SerialDebug) Serial.println("** LIS2DW12 is asleep! **");
+    if (SerialDebug)
+      Serial.println("** LIS2DW12 is asleep! **");
 
     detachInterrupt(LIS2DW12_intPin2);      // Detach the LIS2DW12 "Go to sleep" interrupt so it doesn't spuriously wake the STM32L0
     LIS2DW12.deactivateNoMotionInterrupt(); // disable no-motion interrupt to save power
 
-   digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH);  // toggle blue led when no motion detected
+    digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // toggle blue led when no motion detected
   }                            /* end of LIS2DW12 sleep detect */
 
-  
   /*GNSS*/
   if (GNSS.location(myLocation))
   {
-    if (SerialDebug) {
-    Serial.print("LOCATION: ");
-    Serial.print(fixTypeString[myLocation.fixType()]);
+    if (SerialDebug)
+    {
+      Serial.print("LOCATION: "); Serial.print(fixTypeString[myLocation.fixType()]);
     }
 
-  if (myLocation.fixType() != GNSSLocation::TYPE_NONE)
-  {
+    if (myLocation.fixType() != GNSSLocation::TYPE_NONE)
+    {
       Hour = myLocation.hours();
       Minute = myLocation.minutes();
       Second = myLocation.seconds();
@@ -403,7 +405,8 @@ void loop()
       Month = myLocation.month();
       Day = myLocation.day();
 
-      if (SerialDebug) {
+      if (SerialDebug)
+      {
         Serial.print(fixQualityString[myLocation.fixQuality()]);
         Serial.print(" ");
         Serial.print(myLocation.year());
@@ -425,11 +428,17 @@ void loop()
         if (myLocation.millis() <= 99) { Serial.print("0"); }
         Serial.print(myLocation.millis());
       }
-      if (myLocation.leapSeconds() != GNSSLocation::LEAP_SECONDS_UNDEFINED) {
-                if(SerialDebug) Serial.print(" ");
-                if(SerialDebug) Serial.print(myLocation.leapSeconds());
-        if (!myLocation.fullyResolved()) {
-                    if(SerialDebug) Serial.print("D");
+      if (myLocation.leapSeconds() != GNSSLocation::LEAP_SECONDS_UNDEFINED)
+      {
+        if (SerialDebug)
+        {
+          Serial.print(" ");
+          Serial.print(myLocation.leapSeconds());
+        }
+        if (!myLocation.fullyResolved())
+        {
+          if (SerialDebug)
+            Serial.print("D");
         }
       }
 
@@ -441,33 +450,24 @@ void loop()
         myLocation.longitude(longOut);
         Alt = myLocation.altitude();
         EPE = myLocation.ehpe(); // use this as accuracy figure of merit
-        if (SerialDebug) {
-        Serial.print(" LLA=");
-        Serial.print(Lat, 7);
-        Serial.print(",");
-        Serial.print(Long, 7);
-        Serial.print(",");
-        Serial.print(Alt, 3);
-        Serial.print(" EPE=");
-        Serial.print(EPE, 3);
-        Serial.print(",");
-        Serial.print(myLocation.evpe(), 3);
-        Serial.print(" SATELLITES=");
-        Serial.print(myLocation.satellites());
-        Serial.print(" DOP=");
-        Serial.print(myLocation.hdop(), 2);
-        Serial.print(",");
-        Serial.print(myLocation.vdop(), 2);
+        if (SerialDebug)
+        {
+          Serial.print(" LLA="); Serial.print(Lat, 7); Serial.print(",");
+          Serial.print(Long, 7); Serial.print(","); Serial.print(Alt, 3);
+          Serial.print(" EPE="); Serial.print(EPE, 3); Serial.print(","); Serial.print(myLocation.evpe(), 3);
+          Serial.print(" SATELLITES="); Serial.print(myLocation.satellites());
+          Serial.print(" DOP="); Serial.print(myLocation.hdop(), 2); Serial.print(","); Serial.print(myLocation.vdop(), 2);
           Serial.println();
         }
         // Put the CAM M8Q to sleep once 3D fix with sufficient accuracy is obtained
-        if( (myLocation.fixType() != GNSSLocation::TYPE_2D) && (EPE <= 50.0f) && myLocation.fullyResolved())  // 10 is about as low as one should go, 50 is acceptable
-        {
-            if (!isTracking)
-                {
+        if ((myLocation.fixType() != GNSSLocation::TYPE_2D) && (EPE <= 50.0f) && myLocation.fullyResolved())
+        { // 10 is about as low as one should go, 50 is acceptable 
+          if (!isTracking)
+          {
             isTracking = true;
 
-                    if(SerialDebug) Serial.println("***GNSS go to sleep!***");
+            if (SerialDebug)
+              Serial.println("***GNSS go to sleep!***");
             GNSS.suspend();   // once we have a good 3D location fix put CAM M8Q to sleep
             callbackLoRaTx(); // update dashboard/backend via LoRaWAN
           }
@@ -475,103 +475,124 @@ void loop()
       }
     }
 
- if(SerialDebug) Serial.println();
+    if (SerialDebug)
+      Serial.println();
 
   } /* end of GNSS Location handling */
 
-    if (GNSS.satellites(mySatellites))
+  if (GNSS.satellites(mySatellites))
+  {
+    if (SerialDebug)
     {
-
-    if (SerialDebug) {
       Serial.print("SATELLITES: ");
-      Serial.print(mySatellites.count());
-      Serial.println();
+      Serial.println(mySatellites.count());
     }
 
     for (unsigned int index = 0; index < mySatellites.count(); index++)
     {
       unsigned int svid = mySatellites.svid(index);
 
-  if ((svid >= 1) && (svid <= 32))
-  {
-      if(SerialDebug) Serial.print("    ");
+      if ((svid >= 1) && (svid <= 32))
+      {
+        if (SerialDebug)
+          Serial.print("    ");
 
-      if (svid <= 9)
-      {
-    if(SerialDebug) Serial.print("  G");
-    if(SerialDebug) Serial.print(svid);
+        if (svid <= 9)
+        {
+          if (SerialDebug)
+            Serial.print("  G");
+          if (SerialDebug)
+            Serial.print(svid);
         }
-      else
-      {
-    if(SerialDebug) Serial.print(" G");
-    if(SerialDebug) Serial.print(svid);
+        else
+        {
+          if (SerialDebug)
+            Serial.print(" G");
+          if (SerialDebug)
+            Serial.print(svid);
         }
       }
-  else if ((svid >= 65) && (svid <= 96))
-  {
-      if(SerialDebug) Serial.print("    ");
+      else if ((svid >= 65) && (svid <= 96))
+      {
+        if (SerialDebug)
+          Serial.print("    ");
 
-      if ((svid - 64) <= 9)
-      {
-    if(SerialDebug) Serial.print("  R");
-    if(SerialDebug) Serial.print(svid - 64);
+        if ((svid - 64) <= 9)
+        {
+          if (SerialDebug)
+            Serial.print("  R");
+          if (SerialDebug)
+            Serial.print(svid - 64);
         }
-      else
-      {
-    if(SerialDebug) Serial.print(" R");
-    if(SerialDebug) Serial.print(svid - 64);
+        else
+        {
+          if (SerialDebug)
+            Serial.print(" R");
+          if (SerialDebug)
+            Serial.print(svid - 64);
         }
       }
-  else if ((svid >= 120) && (svid <= 158))
-  {
-        if (SerialDebug) {
+      else if ((svid >= 120) && (svid <= 158))
+      {
+        if (SerialDebug)
+        {
           Serial.print("    ");
           Serial.print("S");
           Serial.print(svid);
         }
       }
-  else if ((svid >= 173) && (svid <= 182))
-  {
-        if (SerialDebug) {
+      else if ((svid >= 173) && (svid <= 182))
+      {
+        if (SerialDebug)
+        {
           Serial.print("    ");
           Serial.print("  I");
           Serial.print(svid - 172);
         }
       }
-  else if ((svid >= 193) && (svid <= 197))
-  {
-        if (SerialDebug) {
+      else if ((svid >= 193) && (svid <= 197))
+      {
+        if (SerialDebug)
+        {
           Serial.print("    ");
           Serial.print("  Q");
           Serial.print(svid - 192);
         }
       }
-  else if ((svid >= 211) && (svid <= 246))
-  {
-     if(SerialDebug) Serial.print("    ");
-
-      if ((svid - 210) <= 9)
+      else if ((svid >= 211) && (svid <= 246))
       {
-    if(SerialDebug) Serial.print("  E");
-    if(SerialDebug) Serial.print(svid - 210);
+        if (SerialDebug)
+          Serial.print("    ");
+
+        if ((svid - 210) <= 9)
+        {
+          if (SerialDebug)
+            Serial.print("  E");
+          if (SerialDebug)
+            Serial.print(svid - 210);
         }
+        else
+        {
+          if (SerialDebug)
+            Serial.print(" E");
+          if (SerialDebug)
+            Serial.print(svid - 210);
+        }
+      }
+      else if (svid == 255)
+      {
+        if (SerialDebug)
+          Serial.print("    ");
+        if (SerialDebug)
+          Serial.print("R???");
+      }
       else
       {
-    if(SerialDebug) Serial.print(" E");
-    if(SerialDebug) Serial.print(svid - 210);
-        }
-      }
-  else if (svid == 255)
-  {
-      if(SerialDebug) Serial.print("    ");
-      if(SerialDebug) Serial.print("R???");
-      }
-  else
-  {
         continue;
       }
 
-      if (SerialDebug) {
+      if (SerialDebug)
+      {
         Serial.print(": SNR=");
         Serial.print(mySatellites.snr(index));
         Serial.print(", ELEVATION=");
@@ -580,51 +601,59 @@ void loop()
         Serial.print(mySatellites.azimuth(index));
       }
 
-      if (mySatellites.unhealthy(index)) {
-      if(SerialDebug) Serial.print(", UNHEALTHY");
+      if (mySatellites.unhealthy(index))
+      {
+        if (SerialDebug) Serial.print(", UNHEALTHY");
       }
 
-      if (mySatellites.almanac(index)) {
-      if(SerialDebug) Serial.print(", ALMANAC");
+      if (mySatellites.almanac(index))
+      {
+        if (SerialDebug) Serial.print(", ALMANAC");
       }
 
-      if (mySatellites.ephemeris(index)) {
-      if(SerialDebug) Serial.print(", EPHEMERIS");
+      if (mySatellites.ephemeris(index))
+      {
+        if (SerialDebug) Serial.print(", EPHEMERIS");
       }
 
-      if (mySatellites.autonomous(index)) {
-      if(SerialDebug) Serial.print(", AUTONOMOUS");
+      if (mySatellites.autonomous(index))
+      {
+        if (SerialDebug) Serial.print(", AUTONOMOUS");
       }
 
-      if (mySatellites.correction(index)) {
-      if(SerialDebug) Serial.print(", CORRECTION");
+      if (mySatellites.correction(index))
+      {
+        if (SerialDebug)
+          Serial.print(", CORRECTION");
       }
 
-      if (mySatellites.acquired(index)) {
-      if(SerialDebug) Serial.print(", ACQUIRED");
+      if (mySatellites.acquired(index))
+      {
+        if (SerialDebug) Serial.print(", ACQUIRED");
       }
 
-      if (mySatellites.locked(index)) {
-      if(SerialDebug) Serial.print(", LOCKED");
+      if (mySatellites.locked(index))
+      {
+        if (SerialDebug) Serial.print(", LOCKED");
       }
 
-      if (mySatellites.navigating(index)) {
-      if(SerialDebug) Serial.print(", NAVIGATING");
+      if (mySatellites.navigating(index))
+      {
+        if (SerialDebug) Serial.print(", NAVIGATING");
       }
 
-  if(SerialDebug) Serial.println();
+      if (SerialDebug) Serial.println();
     }
 
   } /* end of GNSS Satellites handling */
-
 
   /*RTC*/
   if (alarmFlag) { // update serial output
     alarmFlag = false;
 
     ax = ay = az = 0.0f;
-    if (InMotion) {
-      
+    if (InMotion)
+    {
       LIS2DW12.readAccelData(accelCount); // get 14-bit signed accel data
 
       // Now we'll calculate the accleration value into actual g's
@@ -632,11 +661,12 @@ void loop()
       ay = (float)accelCount[1] * aRes - offset[1];
       az = (float)accelCount[2] * aRes - offset[2];
 
-      if (SerialDebug) {
+      if (SerialDebug)
+      {
         Serial.println(" ");
         Serial.print("ax = "); Serial.print((int)1000 * ax);
         Serial.print(" ay = "); Serial.print((int)1000 * ay);
-        Serial.print(" az = "); Serial.print((int)1000*az); Serial.println(" mg");
+        Serial.print(" az = "); Serial.print((int)1000 * az); Serial.println(" mg");
         Serial.println(" ");
       }
     }
@@ -645,14 +675,16 @@ void loop()
     digitalWrite(VBAT_en, HIGH);
     VBAT = 1.27f * VDDA * ((float)analogRead(VBAT_sense)) / 4095.0f;
     digitalWrite(VBAT_en, LOW);
-    if (SerialDebug) {
+    if (SerialDebug)
+    {
       Serial.print("VBAT = "); Serial.print(VBAT, 2); Serial.println(" V");
     }
 
     tempCount = LIS2DW12.readTempData();      // Read the accel chip temperature adc values
     temperature = ((float)tempCount) + 25.0f; // 8-bit accel chip temperature in degrees Centigrade
     // Print temperature in degrees Centigrade
-    if (SerialDebug) {
+    if (SerialDebug)
+    {
       Serial.print("Accel temperature is "); Serial.print(temperature, 1); Serial.println(" degrees C"); // Print T values to tenths of s degree C
     }
 
@@ -673,7 +705,8 @@ void loop()
     compHumidity = BME280.compensate_H(rawHumidity);
     humidity = (float)compHumidity / 1024.0f; // Humidity in %RH
 
-    if (SerialDebug) {
+    if (SerialDebug)
+    {
       Serial.println("BME280:");
       Serial.print("Altimeter temperature = ");
       Serial.print(temperature_C, 2);
@@ -700,21 +733,18 @@ void loop()
 
     milliseconds = ((subSeconds >> 17) * 1000 + 16384) / 32768;
 
-    if (SerialDebug) {
+    if (SerialDebug)
+    {
       Serial.print("RTC Time = ");
-      if (hours < 10)   {Serial.print("0");Serial.print(hours); } else Serial.print(hours);
+      if (hours < 10) { Serial.print("0"); } Serial.print(hours);
       Serial.print(":");
-      if (minutes < 10) {Serial.print("0"); Serial.print(minutes); } else Serial.print(minutes);
+      if (minutes < 10) { Serial.print("0"); }
+      Serial.print(minutes);
       Serial.print(":");
-      if (seconds < 10) {Serial.print("0"); Serial.print(seconds); } else Serial.print(seconds);
+      if (seconds < 10) { Serial.print("0"); }
+      Serial.print(seconds);
       Serial.print(".");
-        if (milliseconds <= 9) {
-            Serial.print("0");
-        }
-        if (milliseconds <= 99) {
-            Serial.print("0");
-        }
-      Serial.print(milliseconds);
+      if (milliseconds <= 9) { Serial.print("0"); } if (milliseconds <= 99) { Serial.print("0"); } Serial.print(milliseconds);
       Serial.println(" ");
 
       Serial.print("RTC Date = ");
@@ -726,17 +756,18 @@ void loop()
 
   } // end of RTC alarm section
 
-
   // log data to SPI flash
-  if (logData) {
+  if (logData)
+  {
     logData = false;
 
     RTC.getDate(day, month, year);
     RTC.getTime(hours, minutes, seconds, subSeconds);
-    accelCount[0] = 0; accelCount[1] = 0; accelCount[2] = 0;
-    if(InMotion) {LIS2DW12.readAccelData(accelCount); } // read accel data
+    accelCount[0] = 0;
+    accelCount[1] = 0;
+    accelCount[2] = 0;
+    if (InMotion) { LIS2DW12.readAccelData(accelCount); } // read accel data
     rawTempCount = LIS2DW12.readRawTempData(); // Read the 8-bit accel chip temperature register
-
 
     // Store some data in flashPage array until we have a full 256-byte page
     uint8_t bps = 36; // bytes per sector such that 256 bytes per page = sectors per page x bps = 7 x 36 = 252 < 256
@@ -782,46 +813,43 @@ void loop()
     }
 
     // Once the page is full, write it to the SPI flash
-      if (sector_number == 7 && page_number < 0x7FFF)
-      {
+    if (sector_number == 7 && page_number < 0x7FFF)
+    {
       SPIFlash.powerUp();
       SPIFlash.flash_page_program(flashPage, page_number);
-          if(SerialDebug) {Serial.print("***Wrote flash page: "); Serial.println(page_number);}
-          digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // indicate when flash page is written
+      if (SerialDebug) { Serial.print("***Wrote flash page: "); Serial.println(page_number); }
+      digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // indicate when flash page is written
       sector_number = 0;
       page_number++;
       SPIFlash.powerDown(); // Put SPI flash into power down mode
     }
 
     //  if reached the last page stop logging
-      if(page_number >= 0x7FFF) 
-      {
-        if(SerialDebug) {Serial.println("Reached last page of SPI flash!"); Serial.println("Data logging stopped!");}
+    if (page_number >= 0x7FFF)
+    {
+      if (SerialDebug) { Serial.println("Reached last page of SPI flash!"); Serial.println("Data logging stopped!"); }
     }
 
-      digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // blink led when writing a flash page
+    digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // blink led when writing a flash page
 
   } // end of SPI flash logging
 
- 
   STM32L0.stop(); // Enter STOP mode and wait for an interrupt
 
-   
 } /* end of loop*/
-
 
 /* Useful functions */
 
 void callbackLoRaTx(void)
 {
-    if (!LoRaWAN.joined()) 
-    {
+  if (!LoRaWAN.joined())
+  {
     LoRaWAN.joinOTAA(appEui, appKey, devEui);
     delay(1000);
   }
 
-    if (!LoRaWAN.busy() && LoRaWAN.joined())
-    {
+  if (!LoRaWAN.busy() && LoRaWAN.joined())
+  {
     myLPP.reset();
     myLPP.addTemperature(1, temperature_C);
     myLPP.addRelativeHumidity(2, humidity);
@@ -831,9 +859,7 @@ void callbackLoRaTx(void)
 
     LoRaWAN.sendPacket(myLPP.getBuffer(), myLPP.getSize());
   }
-
 }
-
 
 void callbackDataLogger(void)
 {
@@ -841,17 +867,15 @@ void callbackDataLogger(void)
   STM32L0.wakeup();
 }
 
-
 void callbackNoMotionActivity(void)
 {
   GNSS.resume();
   isTracking = false;
 }
 
-
 void callbackInMotionActivity(void)
 {
-  if(InMotion)
+  if (InMotion)
   {
     InMotion = false;
     GNSS.resume();
@@ -859,20 +883,17 @@ void callbackInMotionActivity(void)
   }
 }
 
-
 void alarmMatch()
 {
   alarmFlag = true;
   STM32L0.wakeup();
 }
 
-
 void myinthandler1()
 {
   LIS2DW12_wake_flag = true;
   STM32L0.wakeup();
 }
-
 
 void myinthandler2()
 {

--- a/GasCap/AssetTracker_GasCap_v.02e/AssetTracker_GasCap_v.02e.ino
+++ b/GasCap/AssetTracker_GasCap_v.02e/AssetTracker_GasCap_v.02e.ino
@@ -1,6 +1,6 @@
 /* GasCap Asset Tracker contains:
    CMWX1ZZABZ (STM32L082 and SX1276)
-   LIS2DW12 accelerometer and BME280 environmental sensor 
+   LIS2DW12 accelerometer and BME280 environmental sensor
    CAM M8Q Concurrent GNSS engine
    MX25R6435FZAI 8 MByte SPI NOR flash memory
 
@@ -10,7 +10,7 @@
 
    Idea is ultra-low power for longest LiPo battery life so I would run this with
    4.2 MHz clock speed; this reduction plus use of STM32 stop mode means no serial
-   through the USB.  
+   through the USB.
 
     This example code is in the public domain.
 */
@@ -25,7 +25,7 @@
 #include "CayenneLPP.h"
 #include "I2Cdev.h"
 
-//#define Serial Serial3  // use Serial port on Tag Connect if no USB
+// #define Serial Serial3  // use Serial port on Tag Connect if no USB
 bool SerialDebug = true;
 
 // Production Cricket 1
@@ -35,48 +35,48 @@ const char *devEui = "70B3D57ED004F377";
 
 CayenneLPP myLPP(64);
 
-#define I2C_BUS    Wire               // Define the I2C bus (Wire instance) you wish to use
+#define I2C_BUS Wire // Define the I2C bus (Wire instance) you wish to use
 
-I2Cdev             i2c_0(&I2C_BUS);   // Instantiate the I2Cdev object and point to the desired I2C bus
+I2Cdev i2c_0(&I2C_BUS); // Instantiate the I2Cdev object and point to the desired I2C bus
 
-TimerMillis LoRaTimer;                // instantiate LoraWAN timer
-TimerMillis NoMotionActivityTimer;    // instantiate low-frequency timer
-TimerMillis InMotionActivityTimer;    // instantiate high-frequency timer
-TimerMillis DataLoggerTimer;          // instantiate data logger timer
+TimerMillis LoRaTimer;             // instantiate LoraWAN timer
+TimerMillis NoMotionActivityTimer; // instantiate low-frequency timer
+TimerMillis InMotionActivityTimer; // instantiate high-frequency timer
+TimerMillis DataLoggerTimer;       // instantiate data logger timer
 
 // Internal MCU and battery voltage monitor definitions
 // GasCap pin assignments
-#define myLed       10 // blue led 
-#define VBAT_en      2
-#define USER_BTN     2
-#define VBAT_sense  A1
+#define myLed 10 // blue led
+#define VBAT_en 2
+#define USER_BTN 2
+#define VBAT_sense A1
 
 float VDDA, VBAT, VBUS, STM32L0Temp;
-uint32_t UID[3] = {0, 0, 0}; 
+uint32_t UID[3] = {0, 0, 0};
 char buffer[32];
 
 
-//LIS2DW12 definitions
-#define LIS2DW12_intPin1   3    // interrupt1 pin definitions, wake interrupt pin
-#define LIS2DW12_intPin2   A4   // interrupt2 pin definitions, sleep interrupt pin
+// LIS2DW12 definitions
+#define LIS2DW12_intPin1 3  // interrupt1 pin definitions, wake interrupt pin
+#define LIS2DW12_intPin2 A4 // interrupt2 pin definitions, sleep interrupt pin
 
 // Specify sensor parameters //
-LPMODE   lpMode = LIS2DW12_LP_MODE_1;      // choices are low power modes 1, 2, 3, or 4
-MODE     mode   = LIS2DW12_MODE_LOW_POWER; // choices are low power, high performance, and one shot modes
-ODR      odr    = LIS2DW12_ODR_12_5_1_6HZ; //  1.6 Hz in lpMode, max is 200 Hz in LpMode
-FS       fs     = LIS2DW12_FS_2G;          // choices are 2, 4, 8, or 16 g
-BW_FILT  bw     = LIS2DW12_BW_FILT_ODR2;   // choices are ODR divided by 2, 4, 10, or 20
-FIFOMODE fifoMode = BYPASS;                // capture 32 samples of data before wakeup event, about 2 secs at 25 Hz
-bool lowNoise = false;                     // low noise or lowest power
+LPMODE lpMode = LIS2DW12_LP_MODE_1;  // choices are low power modes 1, 2, 3, or 4
+MODE mode = LIS2DW12_MODE_LOW_POWER; // choices are low power, high performance, and one shot modes
+ODR odr = LIS2DW12_ODR_12_5_1_6HZ;   //  1.6 Hz in lpMode, max is 200 Hz in LpMode
+FS fs = LIS2DW12_FS_2G;              // choices are 2, 4, 8, or 16 g
+BW_FILT bw = LIS2DW12_BW_FILT_ODR2;  // choices are ODR divided by 2, 4, 10, or 20
+FIFOMODE fifoMode = BYPASS;          // capture 32 samples of data before wakeup event, about 2 secs at 25 Hz
+bool lowNoise = false;               // low noise or lowest power
 
-float aRes = 0;         // Sensor data scale in mg/LSB
-int16_t accelCount[3];  // Stores the 16-bit signed accelerometer sensor output
-int16_t tempCount;      // 8-bit signed temperature output
-uint8_t rawTempCount;   // raw temperature output
-float   temperature;    // Stores the real internal chip temperature in degrees Celsius
-float ax, ay, az;       // variables to hold latest sensor data values 
-float offset[3];        // holds accel bias offsets
-float stress[3];        // holds results of the self test
+float aRes = 0;        // Sensor data scale in mg/LSB
+int16_t accelCount[3]; // Stores the 16-bit signed accelerometer sensor output
+int16_t tempCount;     // 8-bit signed temperature output
+uint8_t rawTempCount;  // raw temperature output
+float temperature;     // Stores the real internal chip temperature in degrees Celsius
+float ax, ay, az;      // variables to hold latest sensor data values
+float offset[3];       // holds accel bias offsets
+float stress[3];       // holds results of the self test
 uint8_t status = 0, wakeSource = 0, FIFOstatus = 0, numFIFOSamples = 0;
 
 // Logic flags to keep track of device states
@@ -97,19 +97,19 @@ LIS2DW12 LIS2DW12(&i2c_0); // instantiate LIS2DW12 class
  BME280Sleep, forced, forced2, normal //operation modes
  t_00_5ms = 0, t_62_5ms, t_125ms, t_250ms, t_500ms, t_1000ms, t_10ms, t_20ms // determines sample rate
  */
-uint8_t Posr = P_OSR_01, Hosr = H_OSR_01, Tosr = T_OSR_01, Mode = Sleep, IIRFilter = full, SBy = t_1000ms;     // set pressure amd temperature output data rate
+uint8_t Posr = P_OSR_01, Hosr = H_OSR_01, Tosr = T_OSR_01, Mode = Sleep, IIRFilter = full, SBy = t_1000ms; // set pressure amd temperature output data rate
 
-int32_t rawPress, rawTemp, rawHumidity, compTemp;   // pressure, humidity, and temperature raw count output for BME280
-uint32_t compHumidity, compPress;                   // variables to hold compensated BME280 humidity and pressure values
+int32_t rawPress, rawTemp, rawHumidity, compTemp;                 // pressure, humidity, and temperature raw count output for BME280
+uint32_t compHumidity, compPress;                                 // variables to hold compensated BME280 humidity and pressure values
 float temperature_C, temperature_F, pressure, humidity, altitude; // Scaled output of the BME280
 
 BME280 BME280(&i2c_0); // instantiate BME280 class
 
 
 // CAM M8Q GNSS configuration
-#define GNSS_en      5     // enable for GNSS 3.0 V LDO
-#define pps          4     // 1 Hz fix pulse
-#define GNSS_backup A0     // RTC backup for MAX M8Q
+#define GNSS_en 5      // enable for GNSS 3.0 V LDO
+#define pps 4          // 1 Hz fix pulse
+#define GNSS_backup A0 // RTC backup for MAX M8Q
 
 GNSSLocation myLocation;
 GNSSSatellites mySatellites;
@@ -124,33 +124,33 @@ uint16_t count = 0, fixType = 0, fixQuality, latBytes[4], longBytes[4], tempByte
 int32_t latOut, longOut;
 float Temperature, Long, Lat, Alt, EPE;
 
-  static const char *fixTypeString[] = {
-      "NONE",
-      "TIME",
-      "2D",
-      "3D",
-  };
+static const char *fixTypeString[] = {
+    "NONE",
+    "TIME",
+    "2D",
+    "3D",
+};
 
-  static const char *fixQualityString[] = {
-      "",
-      "",
-      "/DIFFERENTIAL",
-      "/PRECISE",
-      "/RTK_FIXED",
-      "/RTK_FLOAT",
-      "/ESTIMATED",
-      "/MANUAL",
-      "/SIMULATION",
-  };
+static const char *fixQualityString[] = {
+    "",
+    "",
+    "/DIFFERENTIAL",
+    "/PRECISE",
+    "/RTK_FIXED",
+    "/RTK_FLOAT",
+    "/ESTIMATED",
+    "/MANUAL",
+    "/SIMULATION",
+};
 
 
 // SPI Flash: 64 MBit (8 MByte) SPI Flash 32,768, 256-byte pages
 #define csPin 25 // SPI Flash chip select pin
 
 uint8_t flash_id[3] = {0, 0, 0};
-uint16_t page_number = 0;     // set the page number for flash page write
-uint8_t  sector_number = 0;   // set the sector number for sector write
-uint8_t  flashPage[256];      // array to hold the data for flash page write
+uint16_t page_number = 0;  // set the page number for flash page write
+uint8_t sector_number = 0; // set the sector number for sector write
+uint8_t flashPage[256];    // array to hold the data for flash page write
 volatile bool logData = false;
 
 SPIFlash SPIFlash(csPin);
@@ -158,20 +158,20 @@ SPIFlash SPIFlash(csPin);
 
 void setup()
 {
-  if(SerialDebug) {
+  if (SerialDebug) {
     Serial.begin(115200);
     Serial.println("Serial enabled!");
     delay(5000);
   }
-  
+
   STM32L0.getUID(UID);
-  if(SerialDebug) {Serial.print("STM32L0 MCU UID = 0x"); Serial.print(UID[0], HEX); Serial.print(UID[1], HEX); Serial.println(UID[2], HEX); }
+  if (SerialDebug) {Serial.print("STM32L0 MCU UID = 0x"); Serial.print(UID[0], HEX); Serial.print(UID[1], HEX); Serial.println(UID[2], HEX); }
 
   LoRaWAN.getDevEui(buffer, 18);
-  if(SerialDebug) {Serial.print("STM32L0 Device EUI = "); Serial.println(buffer); }
+  if (SerialDebug) {Serial.print("STM32L0 Device EUI = "); Serial.println(buffer); }
   
   pinMode(myLed, OUTPUT);
-  digitalWrite(myLed, HIGH);  // start with blue led off, since active LOW
+  digitalWrite(myLed, HIGH); // start with blue led off, since active LOW
 
   pinMode(VBAT_en, OUTPUT);
   digitalWrite(VBAT_en, LOW);
@@ -188,22 +188,22 @@ void setup()
   GNSS.setConstellation(GNSS.CONSTELLATION_GPS_AND_GLONASS); // choose satellites
   while (GNSS.busy()) { } // wait for set to complete
 
-  GNSS.setAntenna(GNSS.ANTENNA_INTERNAL); // GNSS.ANTENNA_INTERNAL 
+  GNSS.setAntenna(GNSS.ANTENNA_INTERNAL); // GNSS.ANTENNA_INTERNAL
   while (GNSS.busy()) { } // wait for set to complete
 
-  GNSS.enableWakeup();  // allow GNSS sleep and wakeup
+  GNSS.enableWakeup(); // allow GNSS sleep and wakeup
 
-  pinMode(LIS2DW12_intPin1, INPUT);  // define LIS2DW12 wake and sleep interrupt pins as L082 inputs
+  pinMode(LIS2DW12_intPin1, INPUT); // define LIS2DW12 wake and sleep interrupt pins as L082 inputs
   pinMode(LIS2DW12_intPin2, INPUT);
 
   /* initialize two wire bus */
-  I2C_BUS.begin();                // Set master mode, default on SDA/SCL for STM32L0
-  I2C_BUS.setClock(400000);       // I2C frequency at 400 kHz
+  I2C_BUS.begin();          // Set master mode, default on SDA/SCL for STM32L0
+  I2C_BUS.setClock(400000); // I2C frequency at 400 kHz
   delay(100);
 
-  i2c_0.I2Cscan();              // should detect all I2C devices on the bus
+  i2c_0.I2Cscan(); // should detect all I2C devices on the bus
   delay(100);
-  
+
   // Read the LIS2DW12 Chip ID register, this is a good test of communication
   byte LIS2DW12_ChipID = LIS2DW12.getChipID();  // Read CHIP_ID register for LIS2DW12
   if(SerialDebug) {
@@ -217,49 +217,49 @@ void setup()
   Serial.print("BME280 "); Serial.print("I AM "); Serial.print(BME280_ChipID, HEX); Serial.print(" I should be "); Serial.println(0x60, HEX);
   Serial.println(" ");
   }
-  
-  delay(1000);  
-  
+
+  delay(1000);
+
   if(LIS2DW12_ChipID == 0x44 && BME280_ChipID == 0x60) // check if all I2C sensors with WHO_AM_I have acknowledged
   {
-   if(SerialDebug) {Serial.println("LIS2DW12 and BME280 are online..."); Serial.println(" "); }
+   if (SerialDebug) { Serial.println("LIS2DW12 and BME280 are online..."); Serial.println(" "); }
    
-   LIS2DW12.reset();                                                // software reset before initialization
-   delay(100);      
+    LIS2DW12.reset(); // software reset before initialization
+    delay(100);
 
-   LIS2DW12.selfTest(stress);                                       // perform sensor self test
+   LIS2DW12.selfTest(stress); // perform sensor self test
    if(SerialDebug) {
     Serial.print("x-axis self test = "); Serial.print(stress[0], 1); Serial.println("mg, should be between 70 and 1500 mg");
     Serial.print("y-axis self test = "); Serial.print(stress[1], 1); Serial.println("mg, should be between 70 and 1500 mg");
     Serial.print("z-axis self test = "); Serial.print(stress[2], 1); Serial.println("mg, should be between 70 and 1500 mg");
    }
    
-   LIS2DW12.reset();                                                // software reset before initialization
-   delay(100);                                                     
+    LIS2DW12.reset(); // software reset before initialization
+    delay(100);
 
-   aRes = 0.000244f * (1 << fs);                                    // scale resolutions per LSB for the sensor at 14-bit data 
+    aRes = 0.000244f * (1 << fs); // scale resolutions per LSB for the sensor at 14-bit data
 
    if(SerialDebug) Serial.println("hold flat and motionless for bias calibration");
-   delay(5000);
-   LIS2DW12.Compensation(fs, odr, mode, lpMode, bw, lowNoise, offset); // quickly estimate offset bias in normal mode
+    delay(5000);
+    LIS2DW12.Compensation(fs, odr, mode, lpMode, bw, lowNoise, offset); // quickly estimate offset bias in normal mode
    if(SerialDebug) {
     Serial.print("x-axis offset = "); Serial.print(offset[0]*1000.0f, 1); Serial.println(" mg");
     Serial.print("y-axis offset = "); Serial.print(offset[1]*1000.0f, 1); Serial.println(" mg");
     Serial.print("z-axis offset = "); Serial.print(offset[2]*1000.0f, 1); Serial.println(" mg");
    }
 
-   LIS2DW12.init(fs, odr, mode, lpMode, bw, lowNoise);               // Initialize sensor in desired mode for application                     
-   LIS2DW12.configureFIFO(fifoMode, 0x1F); // 32 levels of data
-   delay(100); // let sensor settle
+    LIS2DW12.init(fs, odr, mode, lpMode, bw, lowNoise); // Initialize sensor in desired mode for application
+    LIS2DW12.configureFIFO(fifoMode, 0x1F);             // 32 levels of data
+    delay(100);                                         // let sensor settle
 
-   //Configure the BME280 sensor
-   BME280.reset();                                              // reset BME280 before initilization
-   delay(100);
+    // Configure the BME280 sensor
+    BME280.reset(); // reset BME280 before initilization
+    delay(100);
 
-   BME280.init(Posr, Hosr, Tosr, Mode, IIRFilter, SBy);         // Initialize BME280 altimeter
-   BME280.forced();                                             // get initial data sample, then go back to sleep
+    BME280.init(Posr, Hosr, Tosr, Mode, IIRFilter, SBy); // Initialize BME280 altimeter
+    BME280.forced();                                     // get initial data sample, then go back to sleep
  
-   }
+  }
   else 
   {
    if(LIS2DW12_ChipID != 0x44 && SerialDebug) Serial.println(" LIS2DW12 not functioning!");
@@ -268,24 +268,24 @@ void setup()
 
   pinMode(csPin, OUTPUT); // set SPI chip select as L082 output
   digitalWrite(csPin, HIGH);
- 
+
   // check SPI Flash ID
-  SPIFlash.init();      // start SPI
-  SPIFlash.powerUp();   // MX25R6435FZAI defaults to power down state
-  SPIFlash.getChipID(flash_id);                    // Verify SPI flash communication
-  if(flash_id[0] == 0xC2 && flash_id[1] == 0x28 && flash_id[2] == 0x17 && SerialDebug) {
-    Serial.println(" ");  
+  SPIFlash.init();              // start SPI
+  SPIFlash.powerUp();           // MX25R6435FZAI defaults to power down state
+  SPIFlash.getChipID(flash_id); // Verify SPI flash communication
+  if (flash_id[0] == 0xC2 && flash_id[1] == 0x28 && flash_id[2] == 0x17 && SerialDebug) {
+    Serial.println(" ");
     Serial.println("Found Macronix MX25R6435FZAI with Chip ID = 0xC2, 0x28, 0x17!");
-    Serial.println(" ");  
+    Serial.println(" ");
   }
   else {
-  if(SerialDebug) {
-    Serial.println(" ");  
-    Serial.println("no or unknown SPI flash!");
-    Serial.println(" "); 
-  } 
+    if (SerialDebug) {
+      Serial.println(" ");
+      Serial.println("no or unknown SPI flash!");
+      Serial.println(" ");
+    }
   }
-  
+
   SPIFlash.powerDown(); // power down SPI flash
 
   // Set the RTC time
@@ -301,22 +301,22 @@ void setup()
   VDDA = STM32L0.getVDDA();
   VBUS = STM32L0.getVBUS();
   digitalWrite(VBAT_en, HIGH);
-  VBAT = 1.27f * VDDA * ((float) analogRead(VBAT_sense)) / 4095.0f;
+  VBAT = 1.27f * VDDA * ((float)analogRead(VBAT_sense)) / 4095.0f;
   digitalWrite(VBAT_en, LOW);
   STM32L0Temp = STM32L0.getTemperature();
-  
+
   // Internal STM32L0 functions
-  if(SerialDebug) {
+  if (SerialDebug) {
     Serial.print("VDDA = "); Serial.print(VDDA, 2); Serial.println(" V");
     Serial.print("VBAT = "); Serial.print(VBAT, 2); Serial.println(" V");
     if(VBUS ==  1)  Serial.println("USB Connected!"); 
     Serial.print("STM32L0 MCU Temperature = "); Serial.println(STM32L0Temp, 2);
     Serial.println(" ");
   }
-  
+
   // set alarm to update the RTC periodically
   RTC.setAlarmTime(12, 0, 0);
-  RTC.enableAlarm(RTC.MATCH_SS);  // alarm once per minute
+  RTC.enableAlarm(RTC.MATCH_SS); // alarm once per minute
 
   RTC.attachInterrupt(alarmMatch);
 
@@ -329,81 +329,81 @@ void setup()
     - Korea      KR920
     - US         US915 (64 + 8 channels)
    */
-    LoRaWAN.begin(US915);
-    LoRaWAN.setADR(false);
-    LoRaWAN.setDataRate(1);
-    LoRaWAN.setTxPower(10);
-    LoRaWAN.setSubBand(2); // 1 for SEMTECH, 2 for TTN servers
+  LoRaWAN.begin(US915);
+  LoRaWAN.setADR(false);
+  LoRaWAN.setDataRate(1);
+  LoRaWAN.setTxPower(10);
+  LoRaWAN.setSubBand(2); // 1 for SEMTECH, 2 for TTN servers
 
-    LoRaWAN.joinOTAA(appEui, appKey, devEui);
+  LoRaWAN.joinOTAA(appEui, appKey, devEui);
 
-   // Configure timers
-    LoRaTimer.start(callbackLoRaTx, 60000, 600000);                            // ten minute period, delayed 1 minute
-    NoMotionActivityTimer.start(callbackNoMotionActivity, 0, 3600000);         // low freq (one hour) timer, start right away
-    InMotionActivityTimer.start(callbackInMotionActivity, 600000,  120000);    // high freq (two minute) timer, ten minute delay
-    DataLoggerTimer.start(callbackDataLogger, 60000, 60000);                   // one minute period, delayed 1 minute
+  // Configure timers
+  LoRaTimer.start(callbackLoRaTx, 60000, 600000);                        // ten minute period, delayed 1 minute
+  NoMotionActivityTimer.start(callbackNoMotionActivity, 0, 3600000);     // low freq (one hour) timer, start right away
+  InMotionActivityTimer.start(callbackInMotionActivity, 600000, 120000); // high freq (two minute) timer, ten minute delay
+  DataLoggerTimer.start(callbackDataLogger, 60000, 60000);               // one minute period, delayed 1 minute
 
-    attachInterrupt(LIS2DW12_intPin1, myinthandler1, RISING);  // attach data ready/wake-up interrupt for INT1 pin output of LIS2DW12
-    attachInterrupt(LIS2DW12_intPin2, myinthandler2, RISING);  // attach no-motion          interrupt for INT2 pin output of LIS2DW12 
+  attachInterrupt(LIS2DW12_intPin1, myinthandler1, RISING); // attach data ready/wake-up interrupt for INT1 pin output of LIS2DW12
+  attachInterrupt(LIS2DW12_intPin2, myinthandler2, RISING); // attach no-motion          interrupt for INT2 pin output of LIS2DW12
 
-    LIS2DW12.getStatus(); // read status of interrupts to clear
-}  /* end of setup */
+  LIS2DW12.getStatus(); // read status of interrupts to clear
+} /* end of setup */
 
 
-/* 
- * Everything in the main loop is based on interrupts, so that 
+/*
+ * Everything in the main loop is based on interrupts, so that
  * if there has not been an interrupt event the STM32L082 should be in STOP mode
-*/
- 
+ */
+
 void loop()
 {
   /* LIS2DW12 wake detect*/
   if(LIS2DW12_wake_flag)
   {
-   LIS2DW12_wake_flag = false;    // clear the wake flag if wake event
+    LIS2DW12_wake_flag = false; // clear the wake flag if wake event
 
-   InMotion = true;               // set motion state latch
+    InMotion = true; // set motion state latch
    if(SerialDebug) Serial.println("** LIS2DW12 is awake! **");
 
-   LIS2DW12.activateNoMotionInterrupt();  
-   attachInterrupt(LIS2DW12_intPin2, myinthandler2, RISING);  // attach no-motion interrupt for INT2 pin output of LIS2DW12 
+    LIS2DW12.activateNoMotionInterrupt();
+    attachInterrupt(LIS2DW12_intPin2, myinthandler2, RISING); // attach no-motion interrupt for INT2 pin output of LIS2DW12
 
    digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH);  // toggle blue led when motion detected      
-  } /* end of LIS2DW12 wake detect */
-  
+  }                            /* end of LIS2DW12 wake detect */
+
   
   /* LIS2DW12 sleep detect*/ // Not needed for basic wake/GNSS on motion case
   if(LIS2DW12_sleep_flag)
   {
-   LIS2DW12_sleep_flag = false;                // clear the sleep flag
-   InMotion = false;                           // set motion state latch
+    LIS2DW12_sleep_flag = false; // clear the sleep flag
+    InMotion = false;            // set motion state latch
    if(SerialDebug) Serial.println("** LIS2DW12 is asleep! **");
-      
-   detachInterrupt(LIS2DW12_intPin2);          // Detach the LIS2DW12 "Go to sleep" interrupt so it doesn't spuriously wake the STM32L0
-   LIS2DW12.deactivateNoMotionInterrupt();     // disable no-motion interrupt to save power 
+
+    detachInterrupt(LIS2DW12_intPin2);      // Detach the LIS2DW12 "Go to sleep" interrupt so it doesn't spuriously wake the STM32L0
+    LIS2DW12.deactivateNoMotionInterrupt(); // disable no-motion interrupt to save power
 
    digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH);  // toggle blue led when no motion detected
-  } /* end of LIS2DW12 sleep detect */ 
+  }                            /* end of LIS2DW12 sleep detect */
 
   
   /*GNSS*/
   if (GNSS.location(myLocation))
   {
-  if(SerialDebug) {
+    if (SerialDebug) {
     Serial.print("LOCATION: ");
     Serial.print(fixTypeString[myLocation.fixType()]);
-  }
+    }
 
   if (myLocation.fixType() != GNSSLocation::TYPE_NONE)
   {
-      Hour   = myLocation.hours();
+      Hour = myLocation.hours();
       Minute = myLocation.minutes();
       Second = myLocation.seconds();
-      Year   = myLocation.year();
-      Month  = myLocation.month();
-      Day    = myLocation.day();
-      
-      if(SerialDebug) {
+      Year = myLocation.year();
+      Month = myLocation.month();
+      Day = myLocation.day();
+
+      if (SerialDebug) {
         Serial.print(fixQualityString[myLocation.fixQuality()]);
         Serial.print(" ");
         Serial.print(myLocation.year());
@@ -412,36 +412,36 @@ void loop()
         Serial.print("/");
         Serial.print(myLocation.day());
         Serial.print(" ");
-        if (myLocation.hours() <= 9) {Serial.print("0");}
+        if (myLocation.hours() <= 9) { Serial.print("0"); }
         Serial.print(myLocation.hours());
         Serial.print(":");
-        if (myLocation.minutes() <= 9) {Serial.print("0");}
+        if (myLocation.minutes() <= 9) { Serial.print("0"); }
         Serial.print(myLocation.minutes());
         Serial.print(":");
-        if (myLocation.seconds() <= 9) {Serial.print("0");}
+        if (myLocation.seconds() <= 9) { Serial.print("0"); }
         Serial.print(myLocation.seconds());
         Serial.print(".");
-        if (myLocation.millis() <= 9) {Serial.print("0");}
-        if (myLocation.millis() <= 99) {Serial.print("0");}
+        if (myLocation.millis() <= 9) { Serial.print("0"); }
+        if (myLocation.millis() <= 99) { Serial.print("0"); }
         Serial.print(myLocation.millis());
       }
       if (myLocation.leapSeconds() != GNSSLocation::LEAP_SECONDS_UNDEFINED) {
                 if(SerialDebug) Serial.print(" ");
                 if(SerialDebug) Serial.print(myLocation.leapSeconds());
-                if (!myLocation.fullyResolved()) {
+        if (!myLocation.fullyResolved()) {
                     if(SerialDebug) Serial.print("D");
-                }
-       }
+        }
+      }
 
       if (myLocation.fixType() != GNSSLocation::TYPE_TIME)
       {
-      Lat = myLocation.latitude();
-      myLocation.latitude(latOut);
-      Long = myLocation.longitude();
-      myLocation.longitude(longOut);
-      Alt = myLocation.altitude();
-      EPE = myLocation.ehpe(); // use this as accuracy figure of merit
-      if(SerialDebug) {
+        Lat = myLocation.latitude();
+        myLocation.latitude(latOut);
+        Long = myLocation.longitude();
+        myLocation.longitude(longOut);
+        Alt = myLocation.altitude();
+        EPE = myLocation.ehpe(); // use this as accuracy figure of merit
+        if (SerialDebug) {
         Serial.print(" LLA=");
         Serial.print(Lat, 7);
         Serial.print(",");
@@ -458,22 +458,22 @@ void loop()
         Serial.print(myLocation.hdop(), 2);
         Serial.print(",");
         Serial.print(myLocation.vdop(), 2);
-        Serial.println();
-      }
+          Serial.println();
+        }
         // Put the CAM M8Q to sleep once 3D fix with sufficient accuracy is obtained
         if( (myLocation.fixType() != GNSSLocation::TYPE_2D) && (EPE <= 50.0f) && myLocation.fullyResolved())  // 10 is about as low as one should go, 50 is acceptable
         {
             if (!isTracking)
                 {
-                    isTracking = true;
-                    
+            isTracking = true;
+
                     if(SerialDebug) Serial.println("***GNSS go to sleep!***");
-                    GNSS.suspend();     // once we have a good 3D location fix put CAM M8Q to sleep
-                    callbackLoRaTx();   // update dashboard/backend via LoRaWAN
-                }          
-         }
+            GNSS.suspend();   // once we have a good 3D location fix put CAM M8Q to sleep
+            callbackLoRaTx(); // update dashboard/backend via LoRaWAN
+          }
+        }
       }
-  } 
+    }
 
  if(SerialDebug) Serial.println();
 
@@ -482,7 +482,7 @@ void loop()
     if (GNSS.satellites(mySatellites))
     {
 
-    if(SerialDebug) {
+    if (SerialDebug) {
       Serial.print("SATELLITES: ");
       Serial.print(mySatellites.count());
       Serial.println();
@@ -490,7 +490,7 @@ void loop()
 
     for (unsigned int index = 0; index < mySatellites.count(); index++)
     {
-  unsigned int svid = mySatellites.svid(index);
+      unsigned int svid = mySatellites.svid(index);
 
   if ((svid >= 1) && (svid <= 32))
   {
@@ -500,13 +500,13 @@ void loop()
       {
     if(SerialDebug) Serial.print("  G");
     if(SerialDebug) Serial.print(svid);
-      }
+        }
       else
       {
     if(SerialDebug) Serial.print(" G");
     if(SerialDebug) Serial.print(svid);
+        }
       }
-  }
   else if ((svid >= 65) && (svid <= 96))
   {
       if(SerialDebug) Serial.print("    ");
@@ -515,37 +515,37 @@ void loop()
       {
     if(SerialDebug) Serial.print("  R");
     if(SerialDebug) Serial.print(svid - 64);
-      }
+        }
       else
       {
     if(SerialDebug) Serial.print(" R");
     if(SerialDebug) Serial.print(svid - 64);
+        }
       }
-  }
   else if ((svid >= 120) && (svid <= 158))
   {
-      if(SerialDebug) {
-        Serial.print("    ");
-        Serial.print("S");
-        Serial.print(svid);
+        if (SerialDebug) {
+          Serial.print("    ");
+          Serial.print("S");
+          Serial.print(svid);
+        }
       }
-  }
   else if ((svid >= 173) && (svid <= 182))
   {
-      if(SerialDebug) {
-        Serial.print("    ");
-        Serial.print("  I");
-        Serial.print(svid - 172);
+        if (SerialDebug) {
+          Serial.print("    ");
+          Serial.print("  I");
+          Serial.print(svid - 172);
+        }
       }
-  }
   else if ((svid >= 193) && (svid <= 197))
   {
-      if(SerialDebug) {
-        Serial.print("    ");
-        Serial.print("  Q");
-        Serial.print(svid - 192);
+        if (SerialDebug) {
+          Serial.print("    ");
+          Serial.print("  Q");
+          Serial.print(svid - 192);
+        }
       }
-  }
   else if ((svid >= 211) && (svid <= 246))
   {
      if(SerialDebug) Serial.print("    ");
@@ -554,88 +554,88 @@ void loop()
       {
     if(SerialDebug) Serial.print("  E");
     if(SerialDebug) Serial.print(svid - 210);
-      }
+        }
       else
       {
     if(SerialDebug) Serial.print(" E");
     if(SerialDebug) Serial.print(svid - 210);
+        }
       }
-  }
   else if (svid == 255)
   {
       if(SerialDebug) Serial.print("    ");
       if(SerialDebug) Serial.print("R???");
-  }
+      }
   else
   {
-      continue;
-  }
+        continue;
+      }
 
-  if(SerialDebug) {
-    Serial.print(": SNR=");
-    Serial.print(mySatellites.snr(index));
-    Serial.print(", ELEVATION=");
-    Serial.print(mySatellites.elevation(index));
-    Serial.print(", AZIMUTH=");
-    Serial.print(mySatellites.azimuth(index));
-  }
-  
-  if (mySatellites.unhealthy(index)) {
+      if (SerialDebug) {
+        Serial.print(": SNR=");
+        Serial.print(mySatellites.snr(index));
+        Serial.print(", ELEVATION=");
+        Serial.print(mySatellites.elevation(index));
+        Serial.print(", AZIMUTH=");
+        Serial.print(mySatellites.azimuth(index));
+      }
+
+      if (mySatellites.unhealthy(index)) {
       if(SerialDebug) Serial.print(", UNHEALTHY");
-  }
+      }
 
-  if (mySatellites.almanac(index)) {
+      if (mySatellites.almanac(index)) {
       if(SerialDebug) Serial.print(", ALMANAC");
-  }
+      }
 
-  if (mySatellites.ephemeris(index)) {
+      if (mySatellites.ephemeris(index)) {
       if(SerialDebug) Serial.print(", EPHEMERIS");
-  }
+      }
 
-  if (mySatellites.autonomous(index)) {
+      if (mySatellites.autonomous(index)) {
       if(SerialDebug) Serial.print(", AUTONOMOUS");
-  }
+      }
 
-  if (mySatellites.correction(index)) {
+      if (mySatellites.correction(index)) {
       if(SerialDebug) Serial.print(", CORRECTION");
-  }
+      }
 
-  if (mySatellites.acquired(index)) {
+      if (mySatellites.acquired(index)) {
       if(SerialDebug) Serial.print(", ACQUIRED");
-  }
+      }
 
-  if (mySatellites.locked(index)) {
+      if (mySatellites.locked(index)) {
       if(SerialDebug) Serial.print(", LOCKED");
-  }
+      }
 
-  if (mySatellites.navigating(index)) {
+      if (mySatellites.navigating(index)) {
       if(SerialDebug) Serial.print(", NAVIGATING");
-  }
+      }
 
   if(SerialDebug) Serial.println();
     }
 
-} /* end of GNSS Satellites handling */
+  } /* end of GNSS Satellites handling */
 
 
   /*RTC*/
-  if (alarmFlag) { // update serial output  
+  if (alarmFlag) { // update serial output
     alarmFlag = false;
 
     ax = ay = az = 0.0f;
-    if(InMotion) {
+    if (InMotion) {
       
       LIS2DW12.readAccelData(accelCount); // get 14-bit signed accel data
 
-     // Now we'll calculate the accleration value into actual g's
-      ax = (float)accelCount[0]*aRes - offset[0];  // get actual g value, this depends on scale being set
-      ay = (float)accelCount[1]*aRes - offset[1];   
-      az = (float)accelCount[2]*aRes - offset[2]; 
-     
-      if(SerialDebug) {
+      // Now we'll calculate the accleration value into actual g's
+      ax = (float)accelCount[0] * aRes - offset[0]; // get actual g value, this depends on scale being set
+      ay = (float)accelCount[1] * aRes - offset[1];
+      az = (float)accelCount[2] * aRes - offset[2];
+
+      if (SerialDebug) {
         Serial.println(" ");
-        Serial.print("ax = ");  Serial.print((int)1000*ax);  
-        Serial.print(" ay = "); Serial.print((int)1000*ay); 
+        Serial.print("ax = "); Serial.print((int)1000 * ax);
+        Serial.print(" ay = "); Serial.print((int)1000 * ay);
         Serial.print(" az = "); Serial.print((int)1000*az); Serial.println(" mg");
         Serial.println(" ");
       }
@@ -643,56 +643,56 @@ void loop()
 
     VDDA = STM32L0.getVDDA();
     digitalWrite(VBAT_en, HIGH);
-    VBAT = 1.27f * VDDA * ((float) analogRead(VBAT_sense)) / 4095.0f;
+    VBAT = 1.27f * VDDA * ((float)analogRead(VBAT_sense)) / 4095.0f;
     digitalWrite(VBAT_en, LOW);
-    if(SerialDebug) {
+    if (SerialDebug) {
       Serial.print("VBAT = "); Serial.print(VBAT, 2); Serial.println(" V");
     }
 
-    tempCount = LIS2DW12.readTempData();  // Read the accel chip temperature adc values
-    temperature =  ((float) tempCount) + 25.0f; // 8-bit accel chip temperature in degrees Centigrade
-    // Print temperature in degrees Centigrade      
-    if(SerialDebug) {
-    Serial.print("Accel temperature is ");  Serial.print(temperature, 1);  Serial.println(" degrees C"); // Print T values to tenths of s degree C        
+    tempCount = LIS2DW12.readTempData();      // Read the accel chip temperature adc values
+    temperature = ((float)tempCount) + 25.0f; // 8-bit accel chip temperature in degrees Centigrade
+    // Print temperature in degrees Centigrade
+    if (SerialDebug) {
+      Serial.print("Accel temperature is "); Serial.print(temperature, 1); Serial.println(" degrees C"); // Print T values to tenths of s degree C
     }
 
     // BME280 Data
-    BME280.forced();  // get one data sample, then go back to sleep
-    
-    rawTemp =  BME280.readTemperature();
+    BME280.forced(); // get one data sample, then go back to sleep
+
+    rawTemp = BME280.readTemperature();
     compTemp = BME280.compensate_T(rawTemp);
-    temperature_C = (float) compTemp/100.0f;
-    temperature_F = 9.0f*temperature_C/5.0f + 32.0f;
-     
-    rawPress =  BME280.readPressure();
+    temperature_C = (float)compTemp / 100.0f;
+    temperature_F = 9.0f * temperature_C / 5.0f + 32.0f;
+
+    rawPress = BME280.readPressure();
     compPress = BME280.compensate_P(rawPress);
-    pressure = (float) compPress/25600.0f; // Pressure in mbar
-    altitude = 145366.45f*(1.0f - powf((pressure/1013.25f), 0.190284f));   
-   
-    rawHumidity =  BME280.readHumidity();
+    pressure = (float)compPress / 25600.0f; // Pressure in mbar
+    altitude = 145366.45f * (1.0f - powf((pressure / 1013.25f), 0.190284f));
+
+    rawHumidity = BME280.readHumidity();
     compHumidity = BME280.compensate_H(rawHumidity);
-    humidity = (float)compHumidity/1024.0f; // Humidity in %RH
- 
-    if(SerialDebug){
-    Serial.println("BME280:");
-    Serial.print("Altimeter temperature = "); 
-    Serial.print( temperature_C, 2); 
-    Serial.println(" C"); // temperature in degrees Celsius
-    Serial.print("Altimeter temperature = "); 
-    Serial.print(temperature_F, 2); 
-    Serial.println(" F"); // temperature in degrees Fahrenheit
-    Serial.print("Altimeter pressure = "); 
-    Serial.print(pressure, 2);  
-    Serial.println(" mbar");// pressure in millibar
-    Serial.print("Altitude = "); 
-    Serial.print(altitude, 2); 
-    Serial.println(" feet");
-    Serial.print("Altimeter humidity = "); 
-    Serial.print(humidity, 1);  
-    Serial.println(" %RH");// pressure in millibar
-    Serial.println(" ");
+    humidity = (float)compHumidity / 1024.0f; // Humidity in %RH
+
+    if (SerialDebug) {
+      Serial.println("BME280:");
+      Serial.print("Altimeter temperature = ");
+      Serial.print(temperature_C, 2);
+      Serial.println(" C"); // temperature in degrees Celsius
+      Serial.print("Altimeter temperature = ");
+      Serial.print(temperature_F, 2);
+      Serial.println(" F"); // temperature in degrees Fahrenheit
+      Serial.print("Altimeter pressure = ");
+      Serial.print(pressure, 2);
+      Serial.println(" mbar"); // pressure in millibar
+      Serial.print("Altitude = ");
+      Serial.print(altitude, 2);
+      Serial.println(" feet");
+      Serial.print("Altimeter humidity = ");
+      Serial.print(humidity, 1);
+      Serial.println(" %RH"); // pressure in millibar
+      Serial.println(" ");
     }
-    
+
     // Read RTC
     Serial.println("RTC:");
     RTC.getDate(day, month, year);
@@ -700,7 +700,7 @@ void loop()
 
     milliseconds = ((subSeconds >> 17) * 1000 + 16384) / 32768;
 
-    if(SerialDebug) {
+    if (SerialDebug) {
       Serial.print("RTC Time = ");
       if (hours < 10)   {Serial.print("0");Serial.print(hours); } else Serial.print(hours);
       Serial.print(":");
@@ -721,131 +721,131 @@ void loop()
       Serial.print(year); Serial.print(":"); Serial.print(month); Serial.print(":"); Serial.println(day);
       Serial.println();
     }
-    
+
     digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH);
-        
-    } // end of RTC alarm section
+
+  } // end of RTC alarm section
 
 
-    // log data to SPI flash
-    if(logData) {
-      logData = false;
+  // log data to SPI flash
+  if (logData) {
+    logData = false;
 
     RTC.getDate(day, month, year);
     RTC.getTime(hours, minutes, seconds, subSeconds);
     accelCount[0] = 0; accelCount[1] = 0; accelCount[2] = 0;
     if(InMotion) {LIS2DW12.readAccelData(accelCount); } // read accel data
-    rawTempCount = LIS2DW12.readRawTempData();          // Read the 8-bit accel chip temperature register
+    rawTempCount = LIS2DW12.readRawTempData(); // Read the 8-bit accel chip temperature register
 
 
     // Store some data in flashPage array until we have a full 256-byte page
     uint8_t bps = 36; // bytes per sector such that 256 bytes per page = sectors per page x bps = 7 x 36 = 252 < 256
-    if (sector_number < 7 && page_number < 0x7FFF) { // 32,768 256-byte pages in a 8 MByte flash
-        flashPage[sector_number * bps + 0]  =  (latOut & 0xFF000000) >> 24;  // latitude in bytes
-        flashPage[sector_number * bps + 1]  =  (latOut & 0x00FF0000) >> 16;
-        flashPage[sector_number * bps + 2]  =  (latOut & 0x0000FF00) >> 8;
-        flashPage[sector_number * bps + 3]  =  (latOut & 0x000000FF);
-        flashPage[sector_number * bps + 4]  =  (longOut & 0xFF000000) >> 24; // longitude in bytes
-        flashPage[sector_number * bps + 5]  =  (longOut & 0x00FF0000) >> 16;
-        flashPage[sector_number * bps + 6]  =  (longOut & 0x0000FF00) >> 8;
-        flashPage[sector_number * bps + 7]  =  (longOut & 0x000000FF);
-        flashPage[sector_number * bps + 8]  =  ( (uint16_t(Alt * 10.0f)) & 0xFF00) >> 8;  // MSB GPS altitude
-        flashPage[sector_number * bps + 9]  =  ( (uint16_t(Alt * 10.0f)) & 0x00FF);       // LSB GPS altitude
-        flashPage[sector_number * bps + 10] =  (accelCount[0] & 0xFF00) >> 8;  // x-axis accel MSB
-        flashPage[sector_number * bps + 11] =  (accelCount[0] & 0x00FF);       // x-axis accel LSB  
-        flashPage[sector_number * bps + 12] =  (accelCount[1] & 0xFF00) >> 8;  // y-axis accel MSB
-        flashPage[sector_number * bps + 13] =  (accelCount[1] & 0x00FF);       // y-axis accel LSB  
-        flashPage[sector_number * bps + 14] =  (accelCount[2] & 0xFF00) >> 8;  // z-axis accel MSB
-        flashPage[sector_number * bps + 15] =  (accelCount[2] & 0x00FF);       // z-axis accel LSB  
-        flashPage[sector_number * bps + 16] =  (compTemp & 0xFF000000) >> 24;
-        flashPage[sector_number * bps + 17] =  (compTemp & 0x00FF0000) >> 16;
-        flashPage[sector_number * bps + 18] = (compTemp & 0x0000FF00) >> 8;
-        flashPage[sector_number * bps + 19] = (compTemp & 0x000000FF);
-        flashPage[sector_number * bps + 20] = (compHumidity & 0xFF000000) >> 24;
-        flashPage[sector_number * bps + 21] = (compHumidity & 0x00FF0000) >> 16;
-        flashPage[sector_number * bps + 22] = (compHumidity & 0x0000FF00) >> 8;
-        flashPage[sector_number * bps + 23] = (compHumidity & 0x000000FF);
-        flashPage[sector_number * bps + 24] = (compPress & 0xFF000000) >> 24;
-        flashPage[sector_number * bps + 25] = (compPress & 0x00FF0000) >> 16;
-        flashPage[sector_number * bps + 26] = (compPress & 0x0000FF00) >> 8;
-        flashPage[sector_number * bps + 27] = (compPress & 0x000000FF);        
-        flashPage[sector_number * bps + 28] =  seconds;
-        flashPage[sector_number * bps + 29] =  minutes;
-        flashPage[sector_number * bps + 30] =  hours;
-        flashPage[sector_number * bps + 31] =  day;
-        flashPage[sector_number * bps + 32] =  month;
-        flashPage[sector_number * bps + 33] =  year;
-        flashPage[sector_number * bps + 34] =  ( (uint16_t(VBAT * 100.0f)) & 0xFF00) >> 8;
-        flashPage[sector_number * bps + 35] =  ( (uint16_t(VBAT * 100.0f)) & 0x00FF);
+    if (sector_number < 7 && page_number < 0x7FFF) {                                                                   // 32,768 256-byte pages in a 8 MByte flash
+      flashPage[sector_number * bps + 0] = (latOut & 0xFF000000) >> 24; // latitude in bytes
+      flashPage[sector_number * bps + 1] = (latOut & 0x00FF0000) >> 16;
+      flashPage[sector_number * bps + 2] = (latOut & 0x0000FF00) >> 8;
+      flashPage[sector_number * bps + 3] = (latOut & 0x000000FF);
+      flashPage[sector_number * bps + 4] = (longOut & 0xFF000000) >> 24; // longitude in bytes
+      flashPage[sector_number * bps + 5] = (longOut & 0x00FF0000) >> 16;
+      flashPage[sector_number * bps + 6] = (longOut & 0x0000FF00) >> 8;
+      flashPage[sector_number * bps + 7] = (longOut & 0x000000FF);
+      flashPage[sector_number * bps + 8] = ((uint16_t(Alt * 10.0f)) & 0xFF00) >> 8; // MSB GPS altitude
+      flashPage[sector_number * bps + 9] = ((uint16_t(Alt * 10.0f)) & 0x00FF);      // LSB GPS altitude
+      flashPage[sector_number * bps + 10] = (accelCount[0] & 0xFF00) >> 8;          // x-axis accel MSB
+      flashPage[sector_number * bps + 11] = (accelCount[0] & 0x00FF);               // x-axis accel LSB
+      flashPage[sector_number * bps + 12] = (accelCount[1] & 0xFF00) >> 8;          // y-axis accel MSB
+      flashPage[sector_number * bps + 13] = (accelCount[1] & 0x00FF);               // y-axis accel LSB
+      flashPage[sector_number * bps + 14] = (accelCount[2] & 0xFF00) >> 8;          // z-axis accel MSB
+      flashPage[sector_number * bps + 15] = (accelCount[2] & 0x00FF);               // z-axis accel LSB
+      flashPage[sector_number * bps + 16] = (compTemp & 0xFF000000) >> 24;
+      flashPage[sector_number * bps + 17] = (compTemp & 0x00FF0000) >> 16;
+      flashPage[sector_number * bps + 18] = (compTemp & 0x0000FF00) >> 8;
+      flashPage[sector_number * bps + 19] = (compTemp & 0x000000FF);
+      flashPage[sector_number * bps + 20] = (compHumidity & 0xFF000000) >> 24;
+      flashPage[sector_number * bps + 21] = (compHumidity & 0x00FF0000) >> 16;
+      flashPage[sector_number * bps + 22] = (compHumidity & 0x0000FF00) >> 8;
+      flashPage[sector_number * bps + 23] = (compHumidity & 0x000000FF);
+      flashPage[sector_number * bps + 24] = (compPress & 0xFF000000) >> 24;
+      flashPage[sector_number * bps + 25] = (compPress & 0x00FF0000) >> 16;
+      flashPage[sector_number * bps + 26] = (compPress & 0x0000FF00) >> 8;
+      flashPage[sector_number * bps + 27] = (compPress & 0x000000FF);
+      flashPage[sector_number * bps + 28] = seconds;
+      flashPage[sector_number * bps + 29] = minutes;
+      flashPage[sector_number * bps + 30] = hours;
+      flashPage[sector_number * bps + 31] = day;
+      flashPage[sector_number * bps + 32] = month;
+      flashPage[sector_number * bps + 33] = year;
+      flashPage[sector_number * bps + 34] = ((uint16_t(VBAT * 100.0f)) & 0xFF00) >> 8;
+      flashPage[sector_number * bps + 35] = ((uint16_t(VBAT * 100.0f)) & 0x00FF);
 
-        sector_number++;
-      }
-      
-      // Once the page is full, write it to the SPI flash
+      sector_number++;
+    }
+
+    // Once the page is full, write it to the SPI flash
       if (sector_number == 7 && page_number < 0x7FFF)
       {
-          SPIFlash.powerUp();
-          SPIFlash.flash_page_program(flashPage, page_number);
+      SPIFlash.powerUp();
+      SPIFlash.flash_page_program(flashPage, page_number);
           if(SerialDebug) {Serial.print("***Wrote flash page: "); Serial.println(page_number);}
           digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // indicate when flash page is written
-          sector_number = 0;
-          page_number++;
-          SPIFlash.powerDown();  // Put SPI flash into power down mode
-      }
+      sector_number = 0;
+      page_number++;
+      SPIFlash.powerDown(); // Put SPI flash into power down mode
+    }
 
-      //  if reached the last page stop logging
+    //  if reached the last page stop logging
       if(page_number >= 0x7FFF) 
       {
         if(SerialDebug) {Serial.println("Reached last page of SPI flash!"); Serial.println("Data logging stopped!");}
-      }
+    }
 
       digitalWrite(myLed, LOW); delay(1); digitalWrite(myLed, HIGH); // blink led when writing a flash page
-          
-    } // end of SPI flash logging
-    
+
+  } // end of SPI flash logging
+
  
-    STM32L0.stop();        // Enter STOP mode and wait for an interrupt
-    
+  STM32L0.stop(); // Enter STOP mode and wait for an interrupt
+
    
-}  /* end of loop*/
+} /* end of loop*/
 
 
 /* Useful functions */
 
 void callbackLoRaTx(void)
-{     
+{
     if (!LoRaWAN.joined()) 
     {
-        LoRaWAN.joinOTAA(appEui, appKey, devEui);
-        delay(1000);
-    }
-        
+    LoRaWAN.joinOTAA(appEui, appKey, devEui);
+    delay(1000);
+  }
+
     if (!LoRaWAN.busy() && LoRaWAN.joined())
     {
-        myLPP.reset();
-        myLPP.addTemperature(1, temperature_C);
-        myLPP.addRelativeHumidity(2, humidity);
-        myLPP.addBarometricPressure(3, pressure);
-        myLPP.addAnalogInput(4, VBAT);
-        myLPP.addGPS(5, Lat, Long, Alt);
+    myLPP.reset();
+    myLPP.addTemperature(1, temperature_C);
+    myLPP.addRelativeHumidity(2, humidity);
+    myLPP.addBarometricPressure(3, pressure);
+    myLPP.addAnalogInput(4, VBAT);
+    myLPP.addGPS(5, Lat, Long, Alt);
 
-        LoRaWAN.sendPacket(myLPP.getBuffer(), myLPP.getSize());
-    } 
+    LoRaWAN.sendPacket(myLPP.getBuffer(), myLPP.getSize());
+  }
 
 }
 
 
 void callbackDataLogger(void)
 {
-    logData = true;
-    STM32L0.wakeup();
+  logData = true;
+  STM32L0.wakeup();
 }
 
 
 void callbackNoMotionActivity(void)
 {
-    GNSS.resume();
-    isTracking = false;
+  GNSS.resume();
+  isTracking = false;
 }
 
 
@@ -853,9 +853,9 @@ void callbackInMotionActivity(void)
 {
   if(InMotion)
   {
-   InMotion = false;
-   GNSS.resume();
-   isTracking = false;
+    InMotion = false;
+    GNSS.resume();
+    isTracking = false;
   }
 }
 
@@ -869,7 +869,7 @@ void alarmMatch()
 
 void myinthandler1()
 {
-  LIS2DW12_wake_flag = true; 
+  LIS2DW12_wake_flag = true;
   STM32L0.wakeup();
 }
 

--- a/GasCap/AssetTracker_GasCap_v.02e/BME280.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/BME280.cpp
@@ -1,21 +1,21 @@
 /* 06/16/2017 Copyright Tlera Corporation
- *  
+ *
  *  Created by Kris Winer
- *  
+ *
  This sketch uses SDA/SCL on pins 42/43 (back pads), respectively, and it uses the Dragonfly STM32L476RE Breakout Board.
  The BME280 is a simple but high resolution pressure/humidity/temperature sensor, which can be used in its high resolution
  mode but with power consumption of 20 microAmp, or in a lower resolution mode with power consumption of
  only 1 microAmp. The choice will depend on the application.
- 
+
  Library may be used freely and without limit with attribution.
- 
+
 */
- 
+
 #include "BME280.h"
 #include "I2CDev.h"
 
 
-BME280::BME280(I2Cdev* i2c_bus)
+BME280::BME280(I2Cdev *i2c_bus)
 {
   _i2c_bus = i2c_bus;
 }
@@ -35,33 +35,33 @@ void BME280::reset()
 
 int32_t BME280::readTemperature()
 {
-  uint8_t rawData[3];  // 20-bit temperature register data stored here
-  _i2c_bus->readBytes(BME280_ADDRESS, BME280_TEMP_MSB, 3, &rawData[0]);  
-  return (uint32_t) (((uint32_t) rawData[0] << 24 | (uint32_t) rawData[1] << 16 | (uint32_t) rawData[2] << 8) >> 12);
+  uint8_t rawData[3]; // 20-bit temperature register data stored here
+  _i2c_bus->readBytes(BME280_ADDRESS, BME280_TEMP_MSB, 3, &rawData[0]);
+  return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16 | (uint32_t)rawData[2] << 8) >> 12);
 }
 
 
 int32_t BME280::readPressure()
 {
-  uint8_t rawData[3];  // 20-bit pressure register data stored here
-  _i2c_bus->readBytes(BME280_ADDRESS, BME280_PRESS_MSB, 3, &rawData[0]);  
-  return (uint32_t) (((uint32_t) rawData[0] << 24 | (uint32_t) rawData[1] << 16 | (uint32_t) rawData[2] << 8) >> 12);
+  uint8_t rawData[3]; // 20-bit pressure register data stored here
+  _i2c_bus->readBytes(BME280_ADDRESS, BME280_PRESS_MSB, 3, &rawData[0]);
+  return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16 | (uint32_t)rawData[2] << 8) >> 12);
 }
 
 
 int32_t BME280::BME280::readHumidity()
 {
-  uint8_t rawData[3];  // 20-bit pressure register data stored here
-  _i2c_bus->readBytes(BME280_ADDRESS, BME280_HUM_MSB, 2, &rawData[0]);  
-  return (uint32_t) (((uint32_t) rawData[0] << 24 | (uint32_t) rawData[1] << 16) ) >> 16;
+  uint8_t rawData[3]; // 20-bit pressure register data stored here
+  _i2c_bus->readBytes(BME280_ADDRESS, BME280_HUM_MSB, 2, &rawData[0]);
+  return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16)) >> 16;
 }
 
 
 void BME280::forced()
 {
-    uint8_t temp = _i2c_bus->readByte(BME280_ADDRESS, BME280_CTRL_MEAS);
-    _i2c_bus->writeByte(BME280_ADDRESS, BME280_CTRL_MEAS, temp | Forced);
- 
+  uint8_t temp = _i2c_bus->readByte(BME280_ADDRESS, BME280_CTRL_MEAS);
+  _i2c_bus->writeByte(BME280_ADDRESS, BME280_CTRL_MEAS, temp | Forced);
+
     while( (_i2c_bus->readByte(BME280_ADDRESS, BME280_STATUS)) & 0x10) { } // wait for conversion byte to clear
 }
 
@@ -75,67 +75,67 @@ void BME280::init(uint8_t Posr, uint8_t Hosr, uint8_t Tosr, uint8_t Mode, uint8_
   _i2c_bus->writeByte(BME280_ADDRESS, BME280_CTRL_MEAS, Tosr << 5 | Posr << 2 | Mode);
   // Set standby time interval in normal mode and bandwidth
   _i2c_bus->writeByte(BME280_ADDRESS, BME280_CONFIG, SBy << 5 | IIRFilter << 2);
-  
+
   uint8_t calib[26];
   _i2c_bus->readBytes(BME280_ADDRESS, BME280_CALIB00, 26, &calib[0]);
-  _dig_T1 = (uint16_t)(((uint16_t) calib[1] << 8) | calib[0]);
-  _dig_T2 = ( int16_t)((( int16_t) calib[3] << 8) | calib[2]);
-  _dig_T3 = ( int16_t)((( int16_t) calib[5] << 8) | calib[4]);
-  _dig_P1 = (uint16_t)(((uint16_t) calib[7] << 8) | calib[6]);
-  _dig_P2 = ( int16_t)((( int16_t) calib[9] << 8) | calib[8]);
-  _dig_P3 = ( int16_t)((( int16_t) calib[11] << 8) | calib[10]);
-  _dig_P4 = ( int16_t)((( int16_t) calib[13] << 8) | calib[12]);
-  _dig_P5 = ( int16_t)((( int16_t) calib[15] << 8) | calib[14]);
-  _dig_P6 = ( int16_t)((( int16_t) calib[17] << 8) | calib[16]);
-  _dig_P7 = ( int16_t)((( int16_t) calib[19] << 8) | calib[18]);
-  _dig_P8 = ( int16_t)((( int16_t) calib[21] << 8) | calib[20]);
-  _dig_P9 = ( int16_t)((( int16_t) calib[23] << 8) | calib[22]);
+  _dig_T1 = (uint16_t)(((uint16_t)calib[1] << 8) | calib[0]);
+  _dig_T2 = ( int16_t)((( int16_t)calib[3] << 8) | calib[2]);
+  _dig_T3 = ( int16_t)((( int16_t)calib[5] << 8) | calib[4]);
+  _dig_P1 = (uint16_t)(((uint16_t)calib[7] << 8) | calib[6]);
+  _dig_P2 = ( int16_t)((( int16_t)calib[9] << 8) | calib[8]);
+  _dig_P3 = ( int16_t)(((int16_t)calib[11] << 8) | calib[10]);
+  _dig_P4 = ( int16_t)(((int16_t)calib[13] << 8) | calib[12]);
+  _dig_P5 = ( int16_t)(((int16_t)calib[15] << 8) | calib[14]);
+  _dig_P6 = ( int16_t)(((int16_t)calib[17] << 8) | calib[16]);
+  _dig_P7 = ( int16_t)(((int16_t)calib[19] << 8) | calib[18]);
+  _dig_P8 = ( int16_t)(((int16_t)calib[21] << 8) | calib[20]);
+  _dig_P9 = ( int16_t)(((int16_t)calib[23] << 8) | calib[22]);
   _dig_H1 = calib[25];
   _i2c_bus->readBytes(BME280_ADDRESS, BME280_CALIB26, 7, &calib[0]);
-  _dig_H2 = ( int16_t)((( int16_t) calib[1] << 8) | calib[0]);
+  _dig_H2 = ( int16_t)((( int16_t)calib[1] << 8) | calib[0]);
   _dig_H3 = calib[2];
-  _dig_H4 = ( int16_t)(((( int16_t) calib[3] << 8) | (0x0F & calib[4]) << 4) >> 4);
-  _dig_H5 = ( int16_t)(((( int16_t) calib[5] << 8) | (0xF0 & calib[4]) ) >> 4 );
+  _dig_H4 = ( int16_t)((((int16_t)calib[3] << 8) | (0x0F & calib[4]) << 4) >> 4);
+  _dig_H5 = ( int16_t)((((int16_t)calib[5] << 8) | (0xF0 & calib[4])) >> 4);
   _dig_H6 = calib[6];
-/*  
-  Serial.println("Calibration coefficients:");
-  Serial.print("_dig_T1 ="); 
-  Serial.println(_dig_T1);
-  Serial.print("_dig_T2 ="); 
-  Serial.println(_dig_T2);
-  Serial.print("_dig_T3 ="); 
-  Serial.println(_dig_T3);
-  Serial.print("_dig_P1 ="); 
-  Serial.println(_dig_P1);
-  Serial.print("_dig_P2 ="); 
-  Serial.println(_dig_P2);
-  Serial.print("_dig_P3 ="); 
-  Serial.println(_dig_P3);
-  Serial.print("_dig_P4 ="); 
-  Serial.println(_dig_P4);
-  Serial.print("_dig_P5 ="); 
-  Serial.println(_dig_P5);
-  Serial.print("_dig_P6 ="); 
-  Serial.println(_dig_P6);
-  Serial.print("_dig_P7 ="); 
-  Serial.println(_dig_P7);
-  Serial.print("_dig_P8 ="); 
-  Serial.println(_dig_P8);
-  Serial.print("_dig_P9 ="); 
-  Serial.println(_dig_P9);
-  Serial.print("_dig_H1 ="); 
-  Serial.println(_dig_H1);
-  Serial.print("_dig_H2 ="); 
-  Serial.println(_dig_H2);
-  Serial.print("_dig_H3 ="); 
-  Serial.println(_dig_H3);
-  Serial.print("_dig_H4 ="); 
-  Serial.println(_dig_H4);
-  Serial.print("_dig_H5 ="); 
-  Serial.println(_dig_H5);
-  Serial.print("_dig_H6 ="); 
-  Serial.println(_dig_H6);
-  */
+  /*
+    Serial.println("Calibration coefficients:");
+    Serial.print("_dig_T1 =");
+    Serial.println(_dig_T1);
+    Serial.print("_dig_T2 =");
+    Serial.println(_dig_T2);
+    Serial.print("_dig_T3 =");
+    Serial.println(_dig_T3);
+    Serial.print("_dig_P1 =");
+    Serial.println(_dig_P1);
+    Serial.print("_dig_P2 =");
+    Serial.println(_dig_P2);
+    Serial.print("_dig_P3 =");
+    Serial.println(_dig_P3);
+    Serial.print("_dig_P4 =");
+    Serial.println(_dig_P4);
+    Serial.print("_dig_P5 =");
+    Serial.println(_dig_P5);
+    Serial.print("_dig_P6 =");
+    Serial.println(_dig_P6);
+    Serial.print("_dig_P7 =");
+    Serial.println(_dig_P7);
+    Serial.print("_dig_P8 =");
+    Serial.println(_dig_P8);
+    Serial.print("_dig_P9 =");
+    Serial.println(_dig_P9);
+    Serial.print("_dig_H1 =");
+    Serial.println(_dig_H1);
+    Serial.print("_dig_H2 =");
+    Serial.println(_dig_H2);
+    Serial.print("_dig_H3 =");
+    Serial.println(_dig_H3);
+    Serial.print("_dig_H4 =");
+    Serial.println(_dig_H4);
+    Serial.print("_dig_H5 =");
+    Serial.println(_dig_H5);
+    Serial.print("_dig_H6 =");
+    Serial.println(_dig_H6);
+    */
 }
 
 
@@ -153,27 +153,27 @@ int32_t BME280::compensate_T(int32_t adc_T)
 
 
 // Returns pressure in Pa as unsigned 32 bit integer in Q24.8 format (24 integer bits and 8
-//fractional bits).
-//Output value of “24674867” represents 24674867/256 = 96386.2 Pa = 963.862 hPa
+// fractional bits).
+// Output value of “24674867” represents 24674867/256 = 96386.2 Pa = 963.862 hPa
 uint32_t BME280::compensate_P(int32_t adc_P)
 {
   long long var1, var2, p;
   var1 = ((long long)_t_fine) - 128000;
   var2 = var1 * var1 * (long long)_dig_P6;
-  var2 = var2 + ((var1*(long long)_dig_P5)<<17);
-  var2 = var2 + (((long long)_dig_P4)<<35);
-  var1 = ((var1 * var1 * (long long)_dig_P3)>>8) + ((var1 * (long long)_dig_P2)<<12);
-  var1 = (((((long long)1)<<47)+var1))*((long long)_dig_P1)>>33;
-  if(var1 == 0)
+  var2 = var2 + ((var1 * (long long)_dig_P5) << 17);
+  var2 = var2 + (((long long)_dig_P4) << 35);
+  var1 = ((var1 * var1 * (long long)_dig_P3) >> 8) + ((var1 * (long long)_dig_P2) << 12);
+  var1 = (((((long long)1) << 47) + var1)) * ((long long)_dig_P1) >> 33;
+  if (var1 == 0)
   {
     return 0;
     // avoid exception caused by division by zero
   }
   p = 1048576 - adc_P;
-  p = (((p<<31) - var2)*3125)/var1;
-  var1 = (((long long)_dig_P9) * (p>>13) * (p>>13)) >> 25;
-  var2 = (((long long)_dig_P8) * p)>> 19;
-  p = ((p + var1 + var2) >> 8) + (((long long)_dig_P7)<<4);
+  p = (((p << 31) - var2) * 3125) / var1;
+  var1 = (((long long)_dig_P9) * (p >> 13) * (p >> 13)) >> 25;
+  var2 = (((long long)_dig_P8) * p) >> 19;
+  p = ((p + var1 + var2) >> 8) + (((long long)_dig_P7) << 4);
   return (uint32_t)p;
 }
 
@@ -182,14 +182,14 @@ uint32_t BME280::compensate_P(int32_t adc_P)
 // Output value of “47445”represents 47445/1024= 46.333%RH
 uint32_t BME280::compensate_H(int32_t adc_H)
 {
-int32_t var;
+  int32_t var;
 
-var = (_t_fine - ((int32_t)76800));
-var = (((((adc_H << 14) - (((int32_t)_dig_H4) << 20) - (((int32_t)_dig_H5) * var)) +
-((int32_t)16384)) >> 15) * (((((((var * ((int32_t)_dig_H6)) >> 10) * (((var *
-((int32_t)_dig_H3)) >> 11) + ((int32_t)32768))) >> 10) + ((int32_t)2097152)) * ((int32_t)_dig_H2) + 8192) >> 14));
-var = (var - (((((var >> 15) * (var >> 15)) >> 7) * ((int32_t)_dig_H1)) >> 4));
-var = (var < 0 ? 0 : var); 
-var = (var > 419430400 ? 419430400 : var);
-return(uint32_t)(var >> 12);
+  var = (_t_fine - ((int32_t)76800));
+  var = (((((adc_H << 14) - (((int32_t)_dig_H4) << 20) - (((int32_t)_dig_H5) * var)) +
+    ((int32_t)16384)) >> 15) * (((((((var * ((int32_t)_dig_H6)) >> 10) * (((var *
+    ((int32_t)_dig_H3)) >> 11) + ((int32_t)32768))) >> 10) + ((int32_t)2097152)) * ((int32_t)_dig_H2) + 8192) >> 14));
+  var = (var - (((((var >> 15) * (var >> 15)) >> 7) * ((int32_t)_dig_H1)) >> 4));
+  var = (var < 0 ? 0 : var); 
+  var = (var > 419430400 ? 419430400 : var);
+  return (uint32_t)(var >> 12);
 }

--- a/GasCap/AssetTracker_GasCap_v.02e/BME280.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/BME280.cpp
@@ -12,14 +12,11 @@
 */
 
 #include "BME280.h"
-#include "I2CDev.h"
-
 
 BME280::BME280(I2Cdev *i2c_bus)
 {
   _i2c_bus = i2c_bus;
 }
-
 
 uint8_t BME280::getChipID()
 {
@@ -32,14 +29,12 @@ void BME280::reset()
   _i2c_bus->writeByte(BME280_ADDRESS, BME280_RESET, 0xB6);
 }
 
-
 int32_t BME280::readTemperature()
 {
   uint8_t rawData[3]; // 20-bit temperature register data stored here
   _i2c_bus->readBytes(BME280_ADDRESS, BME280_TEMP_MSB, 3, &rawData[0]);
   return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16 | (uint32_t)rawData[2] << 8) >> 12);
 }
-
 
 int32_t BME280::readPressure()
 {
@@ -48,7 +43,6 @@ int32_t BME280::readPressure()
   return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16 | (uint32_t)rawData[2] << 8) >> 12);
 }
 
-
 int32_t BME280::BME280::readHumidity()
 {
   uint8_t rawData[3]; // 20-bit pressure register data stored here
@@ -56,15 +50,15 @@ int32_t BME280::BME280::readHumidity()
   return (uint32_t)(((uint32_t)rawData[0] << 24 | (uint32_t)rawData[1] << 16)) >> 16;
 }
 
-
 void BME280::forced()
 {
   uint8_t temp = _i2c_bus->readByte(BME280_ADDRESS, BME280_CTRL_MEAS);
   _i2c_bus->writeByte(BME280_ADDRESS, BME280_CTRL_MEAS, temp | Forced);
 
-    while( (_i2c_bus->readByte(BME280_ADDRESS, BME280_STATUS)) & 0x10) { } // wait for conversion byte to clear
+  while ((_i2c_bus->readByte(BME280_ADDRESS, BME280_STATUS)) & 0x10)
+  {
+  } // wait for conversion byte to clear
 }
-
 
 void BME280::init(uint8_t Posr, uint8_t Hosr, uint8_t Tosr, uint8_t Mode, uint8_t IIRFilter, uint8_t SBy)
 {
@@ -138,7 +132,6 @@ void BME280::init(uint8_t Posr, uint8_t Hosr, uint8_t Tosr, uint8_t Mode, uint8_
     */
 }
 
-
 // Returns temperature in DegC, resolution is 0.01 DegC. Output value of
 // “5123” equals 51.23 DegC.
 int32_t BME280::compensate_T(int32_t adc_T)
@@ -150,7 +143,6 @@ int32_t BME280::compensate_T(int32_t adc_T)
   T = (_t_fine * 5 + 128) >> 8;
   return T;
 }
-
 
 // Returns pressure in Pa as unsigned 32 bit integer in Q24.8 format (24 integer bits and 8
 // fractional bits).
@@ -176,7 +168,6 @@ uint32_t BME280::compensate_P(int32_t adc_P)
   p = ((p + var1 + var2) >> 8) + (((long long)_dig_P7) << 4);
   return (uint32_t)p;
 }
-
 
 // Returns humidity in %RH as unsigned 32 bit integer in Q22.10 format (22integer and 10fractional bits).
 // Output value of “47445”represents 47445/1024= 46.333%RH

--- a/GasCap/AssetTracker_GasCap_v.02e/BME280.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/BME280.h
@@ -15,7 +15,7 @@
 #define BME280_h
 
 #include "Arduino.h"
-#include "I2CDev.h"
+#include "I2Cdev.h"
 #include <Wire.h>
 
 /* BME280 registers
@@ -39,7 +39,6 @@
 #define BME280_CALIB26    0xE1
 
 #define BME280_ADDRESS    0x76 // Address of BMP280 altimeter when ADO = 0
-
 
 #define P_OSR_01 0x01
 #define P_OSR_02 0x02
@@ -78,7 +77,6 @@
 #define t_1000ms 0x05
 #define t_10ms   0x06
 #define t_20ms   0x07
-
 
 class BME280
 {

--- a/GasCap/AssetTracker_GasCap_v.02e/BME280.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/BME280.h
@@ -1,16 +1,16 @@
 /* 06/16/2017 Copyright Tlera Corporation
- *  
+ *
  *  Created by Kris Winer
- *  
+ *
  This sketch uses SDA/SCL on pins 42/43 (back pads), respectively, and it uses the Dragonfly STM32L476RE Breakout Board.
  The BME280 is a simple but high resolution pressure/humidity/temperature sensor, which can be used in its high resolution
  mode but with power consumption of 20 microAmp, or in a lower resolution mode with power consumption of
  only 1 microAmp. The choice will depend on the application.
- 
+
  Library may be used freely and without limit with attribution.
- 
+
 */
-  
+
 #ifndef BME280_h
 #define BME280_h
 
@@ -19,8 +19,8 @@
 #include <Wire.h>
 
 /* BME280 registers
-*  http://www.mouser.com/ds/2/783/BST-BME280_DS001-11-844833.pdf
-*/
+ *  http://www.mouser.com/ds/2/783/BST-BME280_DS001-11-844833.pdf
+ */
 #define BME280_HUM_LSB    0xFE
 #define BME280_HUM_MSB    0xFD
 #define BME280_TEMP_XLSB  0xFC
@@ -34,56 +34,56 @@
 #define BME280_STATUS     0xF3
 #define BME280_CTRL_HUM   0xF2
 #define BME280_RESET      0xE0
-#define BME280_ID         0xD0  // should be 0x60
+#define BME280_ID         0xD0 // should be 0x60
 #define BME280_CALIB00    0x88
 #define BME280_CALIB26    0xE1
 
-#define BME280_ADDRESS           0x76   // Address of BMP280 altimeter when ADO = 0
+#define BME280_ADDRESS    0x76 // Address of BMP280 altimeter when ADO = 0
 
 
-#define  P_OSR_01 0x01
-#define  P_OSR_02 0x02
-#define  P_OSR_04 0x03
-#define  P_OSR_08 0x04
-#define  P_OSR_16 0x05
+#define P_OSR_01 0x01
+#define P_OSR_02 0x02
+#define P_OSR_04 0x03
+#define P_OSR_08 0x04
+#define P_OSR_16 0x05
 
-#define  H_OSR_01 0x01
-#define  H_OSR_02 0x02
-#define  H_OSR_04 0x03
-#define  H_OSR_08 0x04
-#define  H_OSR_16 0x05
+#define H_OSR_01 0x01
+#define H_OSR_02 0x02
+#define H_OSR_04 0x03
+#define H_OSR_08 0x04
+#define H_OSR_16 0x05
 
-#define  T_OSR_01 0x01
-#define  T_OSR_02 0x02
-#define  T_OSR_04 0x03
-#define  T_OSR_08 0x04
-#define  T_OSR_16 0x05
+#define T_OSR_01 0x01
+#define T_OSR_02 0x02
+#define T_OSR_04 0x03
+#define T_OSR_08 0x04
+#define T_OSR_16 0x05
 
-#define  full       0x00
-#define  BW0_223ODR 0x01
-#define  BW0_092ODR 0x02
-#define  BW0_042ODR 0x03
-#define  BW0_021ODR 0x04  
+#define full       0x00
+#define BW0_223ODR 0x01
+#define BW0_092ODR 0x02
+#define BW0_042ODR 0x03
+#define BW0_021ODR 0x04
 
-#define  Sleep       0x00
-#define  Forced      0x01
-#define  Forced2     0x02
-#define  Normal      0x03
+#define Sleep   0x00
+#define Forced  0x01
+#define Forced2 0x02
+#define Normal  0x03
 
-#define  t_00_5ms 0x00
-#define  t_62_5ms 0x01
-#define  t_125ms  0x02
-#define  t_250ms  0x03
-#define  t_500ms  0x04
-#define  t_1000ms 0x05
-#define  t_10ms   0x06
-#define  t_20ms   0x07 
+#define t_00_5ms 0x00
+#define t_62_5ms 0x01
+#define t_125ms  0x02
+#define t_250ms  0x03
+#define t_500ms  0x04
+#define t_1000ms 0x05
+#define t_10ms   0x06
+#define t_20ms   0x07
 
 
 class BME280
 {
-  public: 
-  BME280(I2Cdev* i2c_bus);
+public:
+  BME280(I2Cdev *i2c_bus);
   uint8_t getChipID();
   void reset();
   int32_t readTemperature();
@@ -95,12 +95,12 @@ class BME280
   uint32_t compensate_P(int32_t adc_P);
   uint32_t compensate_H(int32_t adc_H);
 
-  private:
-  uint8_t  _dig_H1, _dig_H3, _dig_H6;
+private:
+  uint8_t _dig_H1, _dig_H3, _dig_H6;
   uint16_t _dig_T1, _dig_P1, _dig_H4, _dig_H5;
-  int16_t  _dig_T2, _dig_T3, _dig_P2, _dig_P3, _dig_P4, _dig_P5, _dig_P6, _dig_P7, _dig_P8, _dig_P9, _dig_H2;
-  int32_t  _t_fine;
-  I2Cdev* _i2c_bus;
-  };
+  int16_t _dig_T2, _dig_T3, _dig_P2, _dig_P3, _dig_P4, _dig_P5, _dig_P6, _dig_P7, _dig_P8, _dig_P9, _dig_H2;
+  int32_t _t_fine;
+  I2Cdev *_i2c_bus;
+};
 
 #endif

--- a/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.cpp
@@ -29,118 +29,118 @@
 #include "Arduino.h"
 #include "I2Cdev.h"
 
-I2Cdev::I2Cdev(TwoWire* i2c_bus)                                                                                                             // Class constructor
+I2Cdev::I2Cdev(TwoWire *i2c_bus) // Class constructor
 {
   _i2c_bus = i2c_bus;
 }
 
-I2Cdev::~I2Cdev()                                                                                                                            // Class destructor
+I2Cdev::~I2Cdev() // Class destructor
 {
 }
 
 /**
-* @fn: readByte(uint8_t address, uint8_t subAddress)
-*
-* @brief: Read one byte from an I2C device
-* 
-* @params: I2C slave device address, Register subAddress
-* @returns: unsigned short read
-*/
+ * @fn: readByte(uint8_t address, uint8_t subAddress)
+ *
+ * @brief: Read one byte from an I2C device
+ *
+ * @params: I2C slave device address, Register subAddress
+ * @returns: unsigned short read
+ */
 uint8_t I2Cdev::readByte(uint8_t address, uint8_t subAddress)
 {
-  uint8_t data = 0;                             // `data` will store the register data   
-  _i2c_bus->beginTransmission(address);         // Initialize the Tx buffer
-  _i2c_bus->write(subAddress);                  // Put slave register address in Tx buffer
-  _i2c_bus->endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-  _i2c_bus->requestFrom(address, 1);            // Read one byte from slave register address  
-  data = _i2c_bus->read();                      // Fill Rx buffer with result
-  return data;                                  // Return data read from slave register
+  uint8_t data = 0;                     // `data` will store the register data
+  _i2c_bus->beginTransmission(address); // Initialize the Tx buffer
+  _i2c_bus->write(subAddress);          // Put slave register address in Tx buffer
+  _i2c_bus->endTransmission(false);     // Send the Tx buffer, but send a restart to keep connection alive
+  _i2c_bus->requestFrom(address, 1);    // Read one byte from slave register address
+  data = _i2c_bus->read();              // Fill Rx buffer with result
+  return data;                          // Return data read from slave register
   
 }
 
 
 /**
-* @fn: readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t * dest)
-*
-* @brief: Read multiple bytes from an I2C device
-* 
-* @params: I2C slave device address, Register subAddress, number of btes to be read, aray to store the read data
-* @returns: void
-*/
-void I2Cdev::readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t * dest)
-{  
-  _i2c_bus->beginTransmission(address);   // Initialize the Tx buffer
-  _i2c_bus->write(subAddress);            // Put slave register address in Tx buffer
-  _i2c_bus->endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+ * @fn: readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t * dest)
+ *
+ * @brief: Read multiple bytes from an I2C device
+ *
+ * @params: I2C slave device address, Register subAddress, number of btes to be read, aray to store the read data
+ * @returns: void
+ */
+void I2Cdev::readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t *dest)
+{
+  _i2c_bus->beginTransmission(address); // Initialize the Tx buffer
+  _i2c_bus->write(subAddress);          // Put slave register address in Tx buffer
+  _i2c_bus->endTransmission(false);     // Send the Tx buffer, but send a restart to keep connection alive
   uint8_t i = 0;
-  _i2c_bus->requestFrom(address, count);  // Read bytes from slave register address 
+  _i2c_bus->requestFrom(address, count); // Read bytes from slave register address
   while (_i2c_bus->available()) {
         dest[i++] = _i2c_bus->read(); }   // Put read results in the Rx buffer
 }
 
 
 /**
-* @fn: writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data)
-*
-* @brief: Write one byte to an I2C device
-* 
-* @params: I2C slave device address, Register subAddress, data to be written
-* @returns: void
-*/
+ * @fn: writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data)
+ *
+ * @brief: Write one byte to an I2C device
+ *
+ * @params: I2C slave device address, Register subAddress, data to be written
+ * @returns: void
+ */
 void I2Cdev::writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data)
 {
-  _i2c_bus->beginTransmission(devAddr);  // Initialize the Tx buffer
-  _i2c_bus->write(regAddr);           // Put slave register address in Tx buffer
-  _i2c_bus->write(data);                 // Put data in Tx buffer
-  _i2c_bus->endTransmission();           // Send the Tx buffer
+  _i2c_bus->beginTransmission(devAddr); // Initialize the Tx buffer
+  _i2c_bus->write(regAddr);             // Put slave register address in Tx buffer
+  _i2c_bus->write(data);                // Put data in Tx buffer
+  _i2c_bus->endTransmission();          // Send the Tx buffer
 }
 
 
 /**
-* @fn: writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t data)
-*
-* @brief: Write multiple bytes to an I2C device
-* 
-* @params: I2C slave device address, Register subAddress, byte count, data array to be written
-* @returns: void
-*/
+ * @fn: writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t data)
+ *
+ * @brief: Write multiple bytes to an I2C device
+ *
+ * @params: I2C slave device address, Register subAddress, byte count, data array to be written
+ * @returns: void
+ */
 void I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t count, uint8_t *dest)
 {
   uint8_t temp[1 + count];
-  
+
   temp[0] = regAddr;
   for (uint8_t ii = 0; ii < count; ii++)
-  { 
+  {
     temp[ii + 1] = dest[ii];
   }
-  
-  _i2c_bus->beginTransmission(devAddr);  // Initialize the Tx buffer
-  
+
+  _i2c_bus->beginTransmission(devAddr); // Initialize the Tx buffer
+
   for (uint8_t jj = 0; jj < count + 1; jj++)
   {
-  _i2c_bus->write(temp[jj]);            // Put data in Tx buffer
+    _i2c_bus->write(temp[jj]); // Put data in Tx buffer
   }
-  
-  _i2c_bus->endTransmission();           // Send the Tx buffer
+
+  _i2c_bus->endTransmission(); // Send the Tx buffer
 }
 
 
 uint8_t I2Cdev::pollAddress(uint8_t address)
 {
-    _i2c_bus->beginTransmission(address);
-    uint8_t error = _i2c_bus->endTransmission();
-    return error;
+  _i2c_bus->beginTransmission(address);
+  uint8_t error = _i2c_bus->endTransmission();
+  return error;
 }
 
 
- /**
-* @fn:I2Cscan()
-* @brief: Scan the I2C bus for active I2C slave devices
-* 
-* @params: void
-* @returns: void
-*/
-void I2Cdev::I2Cscan() 
+/**
+ * @fn:I2Cscan()
+ * @brief: Scan the I2C bus for active I2C slave devices
+ *
+ * @params: void
+ * @returns: void
+ */
+void I2Cdev::I2Cscan()
 {
   // Scan for i2c devices
   byte error, address;
@@ -149,7 +149,7 @@ void I2Cdev::I2Cscan()
   Serial.println("Scanning...");
 
   nDevices = 0;
-  for(address = 1; address < 127; address++ ) 
+  for (address = 1; address < 127; address++)
   {
     // The i2c_scanner uses the return value of the Wire.endTransmisstion to see if a device did acknowledge to the address.
     _i2c_bus->beginTransmission(address);
@@ -158,19 +158,19 @@ void I2Cdev::I2Cscan()
     if (error == 0)
     {
       Serial.print("I2C device found at address 0x");
-      if (address<16) 
-      Serial.print("0");
-      Serial.print(address,HEX);
+      if (address < 16)
+        Serial.print("0");
+      Serial.print(address, HEX);
       Serial.println("  !");
       nDevices++;
     }
-    else if (error==4) 
+    else if (error == 4)
     {
       Serial.print("Unknow error at address 0x");
-      if (address<16) 
+      if (address < 16)
         Serial.print("0");
-      Serial.println(address,HEX);
-    }    
+      Serial.println(address, HEX);
+    }
   }
   if (nDevices == 0)
     Serial.println("No I2C devices found\n");

--- a/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.cpp
@@ -55,9 +55,7 @@ uint8_t I2Cdev::readByte(uint8_t address, uint8_t subAddress)
   _i2c_bus->requestFrom(address, 1);    // Read one byte from slave register address
   data = _i2c_bus->read();              // Fill Rx buffer with result
   return data;                          // Return data read from slave register
-  
 }
-
 
 /**
  * @fn: readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t * dest)
@@ -74,10 +72,11 @@ void I2Cdev::readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8
   _i2c_bus->endTransmission(false);     // Send the Tx buffer, but send a restart to keep connection alive
   uint8_t i = 0;
   _i2c_bus->requestFrom(address, count); // Read bytes from slave register address
-  while (_i2c_bus->available()) {
-        dest[i++] = _i2c_bus->read(); }   // Put read results in the Rx buffer
+  while (_i2c_bus->available())
+  {
+    dest[i++] = _i2c_bus->read();
+  } // Put read results in the Rx buffer
 }
-
 
 /**
  * @fn: writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data)
@@ -94,7 +93,6 @@ void I2Cdev::writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data)
   _i2c_bus->write(data);                // Put data in Tx buffer
   _i2c_bus->endTransmission();          // Send the Tx buffer
 }
-
 
 /**
  * @fn: writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t data)
@@ -124,14 +122,12 @@ void I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t count, uint8_t
   _i2c_bus->endTransmission(); // Send the Tx buffer
 }
 
-
 uint8_t I2Cdev::pollAddress(uint8_t address)
 {
   _i2c_bus->beginTransmission(address);
   uint8_t error = _i2c_bus->endTransmission();
   return error;
 }
-
 
 /**
  * @fn:I2Cscan()

--- a/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.h
@@ -32,17 +32,17 @@
 #include <Wire.h>
 
 class I2Cdev {
-    public:
-                                        I2Cdev(TwoWire*);
-                                        ~I2Cdev();                                                                                                                     // Class destructor for durable instances
-         uint8_t                        readByte(uint8_t address, uint8_t subAddress);
-         void                           readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t * dest);
-         void                           writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
-         void                           writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t count, uint8_t *dest);
-         void                           I2Cscan();
-         uint8_t                        pollAddress(uint8_t address);
-    private:
-         TwoWire*                       _i2c_bus;                                                                                                                      // Class constructor argument
+public:
+  I2Cdev(TwoWire *);
+  ~I2Cdev(); // Class destructor for durable instances
+  uint8_t readByte(uint8_t address, uint8_t subAddress);
+  void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t *dest);
+  void writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
+  void writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t count, uint8_t *dest);
+  void I2Cscan();
+  uint8_t pollAddress(uint8_t address);
+private:
+  TwoWire *_i2c_bus; // Class constructor argument
 };
 
 #endif //_I2CDEV_H_

--- a/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/I2Cdev.h
@@ -31,7 +31,8 @@
 
 #include <Wire.h>
 
-class I2Cdev {
+class I2Cdev
+{
 public:
   I2Cdev(TwoWire *);
   ~I2Cdev(); // Class destructor for durable instances
@@ -41,6 +42,7 @@ public:
   void writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t count, uint8_t *dest);
   void I2Cscan();
   uint8_t pollAddress(uint8_t address);
+
 private:
   TwoWire *_i2c_bus; // Class constructor argument
 };

--- a/GasCap/AssetTracker_GasCap_v.02e/LIS2DW12.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/LIS2DW12.cpp
@@ -1,20 +1,20 @@
 /* 9/18/21 Copyright Tlera Corporation
- *  
- *  Created by Kris Winer   
- *  
- *  The LIS2DW12 is an inexpensive (~$1), three-axis, medium-resolution (12- or 14-bit), ultra-low power 
- *  (<1 uA low power mode) accelerometer in a tiny 2 mm x 2 mm LGA12 package with a 192-byte FIFO, 
- *  two multifunction interrupts and widely configurable sample rate (1.6 - 1600 Hz), full range (2 - 16 g), 
- *  low power modes, and interrupt detection behaviors. This accelerometer is nice choice for motion-based 
+ *
+ *  Created by Kris Winer
+ *
+ *  The LIS2DW12 is an inexpensive (~$1), three-axis, medium-resolution (12- or 14-bit), ultra-low power
+ *  (<1 uA low power mode) accelerometer in a tiny 2 mm x 2 mm LGA12 package with a 192-byte FIFO,
+ *  two multifunction interrupts and widely configurable sample rate (1.6 - 1600 Hz), full range (2 - 16 g),
+ *  low power modes, and interrupt detection behaviors. This accelerometer is nice choice for motion-based
  *  wake/sleep, tap detection, step counting, and simple orientation estimation.
- *  
+ *
  *  Library may be used freely and without limit with attribution.
- *  
+ *
  */
 #include "LIS2DW12.h"
 #include "I2CDev.h"
 
-LIS2DW12::LIS2DW12(I2Cdev* i2c_bus)
+LIS2DW12::LIS2DW12(I2Cdev *i2c_bus)
 {
   _i2c_bus = i2c_bus;
 }
@@ -35,198 +35,198 @@ uint8_t LIS2DW12::getStatus()
 
 void LIS2DW12::init(uint8_t fs, uint8_t odr, uint8_t mode, uint8_t lpMode, uint8_t bw, bool lowNoise)
 {
-   // Normal mode configuration //
-   // sample rate (bits 4 - 7), power mode (bits 2-3), and low-power mode (bits 0-1)
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, odr << 4 | mode << 2 | lpMode); 
-   // bandwidth bits (6-7), full-scale range bit (4-5)
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4);           
+  // Normal mode configuration //
+  // sample rate (bits 4 - 7), power mode (bits 2-3), and low-power mode (bits 0-1)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, odr << 4 | mode << 2 | lpMode);
+  // bandwidth bits (6-7), full-scale range bit (4-5)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4);
    if(lowNoise)   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4 | 0x04);   // set low noise bit 2        
 
-   _aRes = 0.000244f * (1 << fs);                                       // scale resolutions per LSB for the sensor at 14-bit data 
+  _aRes = 0.000244f * (1 << fs); // scale resolutions per LSB for the sensor at 14-bit data
 
-   // enable block data update (bit 3) and auto register address increment (bit 2)
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04);    
+  // enable block data update (bit 3) and auto register address increment (bit 2)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04);
 
-   // enable latch interrupt for activity/no activity interrupts
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00); // push pull, active high   
+  // enable latch interrupt for activity/no activity interrupts
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00); // push pull, active high
 
-   // wake up (Bit 5) routed to interrupt 1
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x20); 
-   // sleep change state (bit 6) routed to interrupt 2
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x40); 
-   
-   // enable sleep detect (bit 6), set wake threshold 1 LSB = 1/64 of full scale
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_THS, 0x40 | 0x02); //  62.5 mg threshold for wake on any axis, n x 31.25 mgs at 2 g FS
-   // wake-up from sleep duration (bits 5-6) * n/odr, at 1.6 Hz max is 4/1.6 = 2.5 s, set to 0.625 s
-   // inactivity delay before sleep (bits 0 - 3) 512*n/odr, at 25 Hz, 0 is 16/odr = 10s @ 1.6Hz, 1 is 320s @ 1.6 Hz 
-   // set stationary bit 4
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_DUR, 0x20 | 0x10 | 0x00);  // set inactivity delay before sleep to 10s at 1.6 Hz odr
-   // should limit in-motion GNSS data rate to once per 320s
+  // wake up (Bit 5) routed to interrupt 1
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x20);
+  // sleep change state (bit 6) routed to interrupt 2
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x40);
 
-   // pulse interrupt (bit 7), enable interrupt (bit 5) 
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL_REG7, 0x80 | 0x20);    
+  // enable sleep detect (bit 6), set wake threshold 1 LSB = 1/64 of full scale
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_THS, 0x40 | 0x02); //  62.5 mg threshold for wake on any axis, n x 31.25 mgs at 2 g FS
+  // wake-up from sleep duration (bits 5-6) * n/odr, at 1.6 Hz max is 4/1.6 = 2.5 s, set to 0.625 s
+  // inactivity delay before sleep (bits 0 - 3) 512*n/odr, at 25 Hz, 0 is 16/odr = 10s @ 1.6Hz, 1 is 320s @ 1.6 Hz
+  // set stationary bit 4
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_DUR, 0x20 | 0x10 | 0x00); // set inactivity delay before sleep to 10s at 1.6 Hz odr
+  // should limit in-motion GNSS data rate to once per 320s
+
+  // pulse interrupt (bit 7), enable interrupt (bit 5)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL_REG7, 0x80 | 0x20);
 }
 
 
 void LIS2DW12::activateNoMotionInterrupt()
 {
-  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL,  0x40);           // enable GEN1 (no_Motion) interrupt  
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x40); // enable GEN1 (no_Motion) interrupt
 }
 
 
 void LIS2DW12::deactivateNoMotionInterrupt()
 {
-  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL,  0x00);           // disable GEN1 (no_Motion) interrupt  
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x00); // disable GEN1 (no_Motion) interrupt
 }
 
 
-  void LIS2DW12::Compensation(uint8_t fs, uint8_t odr, uint8_t mode, uint8_t lpMode, uint8_t bw, bool lowNoise, float * offset)
-  {     
-    int16_t temp[3] = {0, 0, 0};
-    int32_t sum[3] = {0, 0, 0};
+void LIS2DW12::Compensation(uint8_t fs, uint8_t odr, uint8_t mode, uint8_t lpMode, uint8_t bw, bool lowNoise, float *offset)
+{
+  int16_t temp[3] = {0, 0, 0};
+  int32_t sum[3] = {0, 0, 0};
 
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04); // Block update and auto increment registers 
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00);    
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x00); 
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x00); 
-    // bandwidth bits (6-7), full-scale range bit (4-5)
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4 );         
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04); // Block update and auto increment registers
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x00);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x00);
+  // bandwidth bits (6-7), full-scale range bit (4-5)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4);
     if(lowNoise) _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, bw << 6 | fs << 4 | 0x04);   // set low noise bit 2        
-    // sample rate (bits 4 - 7), power mode (bits 2-3), and low-power mode (bits 0-1)
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, odr << 4 | mode << 2 | lpMode ); 
+  // sample rate (bits 4 - 7), power mode (bits 2-3), and low-power mode (bits 0-1)
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, odr << 4 | mode << 2 | lpMode);
 
-    _aRes = 0.000244f * (1 << fs);                                       // scale resolutions per LSB for the sensor  
-    delay(100);
+  _aRes = 0.000244f * (1 << fs); // scale resolutions per LSB for the sensor
+  delay(100);
     while( !( getStatus() & 0x01) ) { } // wait for data ready bit
-    readAccelData(temp);                // read and discard data
+  readAccelData(temp); // read and discard data
 
-    for(uint8_t ii = 0; ii < 32; ii++)
-    {
+  for (uint8_t ii = 0; ii < 32; ii++)
+  {
        while( !(getStatus() & 0x01) ) { } // wait for data ready bit
-       readAccelData(temp);
-       sum[0] += (int32_t)temp[0];
-       sum[1] += (int32_t)temp[1];
-       sum[2] += (int32_t)temp[2];
-    }
-     
-     offset[0] = float(sum[0])/32.0f;
-     offset[1] = float(sum[1])/32.0f;
-     offset[2] = float(sum[2])/32.0f;
-     offset[0] *= _aRes;
-     offset[1] *= _aRes;
-     offset[2] *= _aRes;
+    readAccelData(temp);
+    sum[0] += (int32_t)temp[0];
+    sum[1] += (int32_t)temp[1];
+    sum[2] += (int32_t)temp[2];
+  }
+
+  offset[0] = float(sum[0]) / 32.0f;
+  offset[1] = float(sum[1]) / 32.0f;
+  offset[2] = float(sum[2]) / 32.0f;
+  offset[0] *= _aRes;
+  offset[1] *= _aRes;
+  offset[2] *= _aRes;
      if(offset[2] > +0.5f) offset[2] = offset[2] - 1.0f;
      if(offset[2] < -0.5f) offset[2] = offset[2] + 1.0f;
-     } /* end of accel calibration */
+} /* end of accel calibration */
 
 
-   void LIS2DW12::reset()
-   {
-    uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2);  
-    _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, temp | 0x40); // software reset the LIS2DW12
-   }
+void LIS2DW12::reset()
+{
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, temp | 0x40); // software reset the LIS2DW12
+}
 
 
-   void LIS2DW12::selfTest(float * destination)
-   {
-   int16_t temp[3]={0, 0, 0};
-   // 5x sum of 13-bit (except sign) could be as much as 15.25 bits and too big for int16_t, but in 
-   // practice nominal value s are < 1000 on 4 g scale and selfTest values are < 3000 so int16_t OK
-   int16_t posX=0, posY=0, posZ=0, nomX=0, nomY=0, nomZ=0; // 5x sum of 13-bit (except sign) could be
-   
-   // initialize sensor for self test
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04);    
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00);    
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x00); 
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x00); 
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, 0x10);         // set +/- 4g FS, LP filter ODR/2
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, 0x40 | 0x04 ); // set sample rate to 200 Hz, high performance mode
+void LIS2DW12::selfTest(float *destination)
+{
+  int16_t temp[3] = {0, 0, 0};
+  // 5x sum of 13-bit (except sign) could be as much as 15.25 bits and too big for int16_t, but in
+  // practice nominal value s are < 1000 on 4 g scale and selfTest values are < 3000 so int16_t OK
+  int16_t posX = 0, posY = 0, posZ = 0, nomX = 0, nomY = 0, nomZ = 0; // 5x sum of 13-bit (except sign) could be
 
-   float STres = 0.488f; // mg/LSB for 4 g full scale, high performance mode
-   delay(100);
+  // initialize sensor for self test
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL2, 0x08 | 0x04);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL4_INT1_PAD_CTRL, 0x00);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL5_INT2_PAD_CTRL, 0x00);
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL6, 0x10);        // set +/- 4g FS, LP filter ODR/2
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, 0x40 | 0x04); // set sample rate to 200 Hz, high performance mode
+
+  float STres = 0.488f; // mg/LSB for 4 g full scale, high performance mode
+  delay(100);
    while( !( getStatus() & 0x01) ) { } // wait for data ready bit
-   readAccelData(temp);                // read and discard data
-   
-   // nominal axes test
+  readAccelData(temp); // read and discard data
+
+  // nominal axes test
    for (uint8_t ii = 0; ii < 5; ii++){
     while( !(getStatus() & 0x01) ) { } // wait for data ready bit
     readAccelData(temp);
     nomX += temp[0];
     nomY += temp[1];
     nomZ += temp[2];
-   }
-    
-   // positive axes test
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x40); // positive axes
-   delay(100);
+  }
+
+  // positive axes test
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x40); // positive axes
+  delay(100);
    while( !(getStatus() & 0x01) ) { } // wait for data ready bit
-   readAccelData(temp);               // read and discard data
-   
+  readAccelData(temp); // read and discard data
+
    for (uint8_t ii = 0; ii < 5; ii++){
     while( !(getStatus() & 0x01) ) { } // wait for data ready bit
     readAccelData(temp);
     posX += temp[0];
     posY += temp[1];
     posZ += temp[2];
-    }
-   
-   destination[0] = (float)(posX - nomX)*STres/5.0f;
-   destination[1] = (float)(posY - nomY)*STres/5.0f;
-   destination[2] = (float)(posZ - nomZ)*STres/5.0f;
+  }
 
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, 0x00); // disable sensor
-   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00); // disable self test
-/* end of self test*/
+  destination[0] = (float)(posX - nomX) * STres / 5.0f;
+  destination[1] = (float)(posY - nomY) * STres / 5.0f;
+  destination[2] = (float)(posZ - nomZ) * STres / 5.0f;
+
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, 0x00); // disable sensor
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL3, 0x00); // disable self test
+  /* end of self test*/
 }
 
 
   void LIS2DW12::readAccelData(int16_t * destination) {
-  uint8_t rawData[6];  // x/y/z accel register data stored here
+  uint8_t rawData[6];                                                       // x/y/z accel register data stored here
   _i2c_bus->readBytes(LIS2DW12_ADDRESS, LIS2DW12_OUT_X_L, 6, &rawData[0]);  // Read the 6 raw data registers into data array
-  destination[0] = ( (int16_t) ( (int16_t)rawData[1] << 8 ) | rawData[0]) >> 2;     // Turn the MSB and LSB into a signed 14-bit value
-  destination[1] = ( (int16_t) ( (int16_t)rawData[3] << 8 ) | rawData[2]) >> 2;  
-  destination[2] = ( (int16_t) ( (int16_t)rawData[5] << 8 ) | rawData[4]) >> 2; 
-  }
+  destination[0] = ((int16_t)((int16_t)rawData[1] << 8) | rawData[0]) >> 2; // Turn the MSB and LSB into a signed 14-bit value
+  destination[1] = ((int16_t)((int16_t)rawData[3] << 8) | rawData[2]) >> 2;
+  destination[2] = ((int16_t)((int16_t)rawData[5] << 8) | rawData[4]) >> 2;
+}
 
 
   int16_t LIS2DW12::readTempData() {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_OUT_T);    // Read the raw data register  
-  int16_t tmp = (int16_t) ( ((int16_t)temp << 8) | 0x00) >> 8;  // Turn into signed 8-bit temperature value
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_OUT_T); // Read the raw data register
+  int16_t tmp = (int16_t)(((int16_t)temp << 8) | 0x00) >> 8;           // Turn into signed 8-bit temperature value
   return tmp;
-  }
+}
 
 
   uint8_t LIS2DW12::readRawTempData() {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_OUT_T);    // Read the raw data register  
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_OUT_T); // Read the raw data register
   return temp;
-  }
+}
 
 
   void LIS2DW12::powerDown() {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1);    // Read the raw data register  
-  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, temp & 0x0F );    // set odr to 0 (bits 4 - 7)
-  }
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1); // Read the raw data register
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, temp & 0x0F);  // set odr to 0 (bits 4 - 7)
+}
 
 
   void LIS2DW12::powerUp(uint8_t odr) {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1);    // Read the raw data register  
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1);    // Read the raw data register
   _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_CTRL1, temp | odr << 4); // set odr (bits 4 - 7)
-  }
+}
 
 
   uint8_t LIS2DW12::getWakeSource( ) {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_SRC);    // Read wake source register  
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_WAKE_UP_SRC); // Read wake source register
   return temp;
-  }
+}
 
 
   void LIS2DW12::configureFIFO(uint8_t FIFOMode, uint8_t FIFOThreshold) {
-  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_FIFO_CTRL, FIFOMode << 5 | FIFOThreshold );     
-  }
+  _i2c_bus->writeByte(LIS2DW12_ADDRESS, LIS2DW12_FIFO_CTRL, FIFOMode << 5 | FIFOThreshold);
+}
 
 
   uint8_t LIS2DW12::FIFOsamples( ) {
-  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_FIFO_SAMPLES);    // Read FIFO samples register  
+  uint8_t temp = _i2c_bus->readByte(LIS2DW12_ADDRESS, LIS2DW12_FIFO_SAMPLES); // Read FIFO samples register
   return temp;
-  }
+}
   

--- a/GasCap/AssetTracker_GasCap_v.02e/LIS2DW12.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/LIS2DW12.h
@@ -16,7 +16,7 @@
 #define LIS2DW12_h
 
 #include "Arduino.h"
-#include "I2CDev.h"
+#include "I2Cdev.h"
 #include <Wire.h>
 
 /* Register Map LIS2DW12

--- a/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.cpp
@@ -35,14 +35,12 @@ SPIFlash::SPIFlash(uint8_t CSPIN)
   _csPin = CSPIN;
 }
 
-
 void SPIFlash::init()
 {
   SPI.begin();
   delay(2);
 }
 
- 
 void SPIFlash::getChipID(uint8_t *dest)
 {
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
@@ -55,7 +53,6 @@ void SPIFlash::getChipID(uint8_t *dest)
   SPI.endTransaction();
 }
 
-
 void SPIFlash::powerDown()
 {
   write_pause();
@@ -66,7 +63,6 @@ void SPIFlash::powerDown()
   delayMicroseconds(10);
   SPI.endTransaction();
 }
-
 
 void SPIFlash::powerUp()
 {
@@ -79,11 +75,12 @@ void SPIFlash::powerUp()
   SPI.endTransaction();
 }
 
-
 void SPIFlash::write_pause(void)
 {
-  if(flash_wait_for_write) {
-    while(flash_read_status() & STAT_WIP);
+  if (flash_wait_for_write)
+  {
+    while (flash_read_status() & STAT_WIP)
+      ;
     flash_wait_for_write = 0;
   }
 }
@@ -110,7 +107,8 @@ void SPIFlash::flash_read_id(unsigned char *idt)
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_ID);
-  for(uint16_t i = 0; i < 20; i++) {
+  for (uint16_t i = 0; i < 20; i++)
+  {
     *idt++ = SPI.transfer(0x00);
   }
   digitalWrite(_csPin, HIGH);
@@ -153,7 +151,8 @@ void SPIFlash::flash_hard_reset(void)
   delayMicroseconds(50);
   // Wait for the hard reset to finish
   // Don't use flash_wait_for_write here
-  while(flash_read_status() & STAT_WIP);
+  while (flash_read_status() & STAT_WIP)
+    ;
   // The spec says "the device will take
   // approximately tRST=30 microseconds
   // to reset"
@@ -173,7 +172,8 @@ void SPIFlash::flash_chip_erase(boolean wait)
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
   flash_wait_for_write = 1;
-  if(wait)write_pause();
+  if (wait)
+    write_pause();
 }
 
 //=====================================
@@ -281,7 +281,8 @@ void SPIFlash::flash_page_program(unsigned char *wp, int pn)
   SPI.transfer((address >> 8) & 0xFF);
   SPI.transfer(address & 0xFF);
   // Now write 256 bytes to the page
-  for(uint16_t i = 0; i < 256; i++) {
+  for (uint16_t i = 0; i < 256; i++)
+  {
     SPI.transfer(*wp++);
   }
   digitalWrite(_csPin, HIGH);
@@ -306,7 +307,8 @@ void SPIFlash::flash_read_pages(unsigned char *p, int pn, const int n_pages)
   SPI.transfer((address >> 8) & 0xFF);
   SPI.transfer(address & 0xFF);
   // Now read the page's data bytes
-  for(uint16_t i = 0; i < n_pages * 256; i++) {
+  for (uint16_t i = 0; i < n_pages * 256; i++)
+  {
     *rp++ = SPI.transfer(0);
   }
   digitalWrite(_csPin, HIGH);
@@ -334,7 +336,8 @@ void SPIFlash::flash_fast_read_pages(unsigned char *p, int pn, const int n_pages
   // send dummy byte
   SPI.transfer(0);
   // Now read the number of pages required
-  for(uint16_t i = 0; i < n_pages * 256; i++) {
+  for (uint16_t i = 0; i < n_pages * 256; i++)
+  {
     *rp++ = SPI.transfer(0);
   }
   digitalWrite(_csPin, HIGH);

--- a/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.cpp
+++ b/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.cpp
@@ -32,7 +32,7 @@ Sketch based on the work of Pete (El Supremo) as follows:
 
 SPIFlash::SPIFlash(uint8_t CSPIN)
 {
-  _csPin = CSPIN; 
+  _csPin = CSPIN;
 }
 
 
@@ -43,8 +43,8 @@ void SPIFlash::init()
 }
 
  
-void SPIFlash::getChipID(uint8_t * dest)
-{ 
+void SPIFlash::getChipID(uint8_t *dest)
+{
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(0x9F);
@@ -92,21 +92,21 @@ void SPIFlash::write_pause(void)
 // convert a page number to a 24-bit address
 int SPIFlash::page_to_address(int pn)
 {
-  return(pn << 8);
+  return (pn << 8);
 }
 
 //=====================================
 // convert a 24-bit address to a page number
 int SPIFlash::address_to_page(int addr)
 {
-  return(addr >> 8);
+  return (addr >> 8);
 }
 
 //=====================================
 void SPIFlash::flash_read_id(unsigned char *idt)
 {
   write_pause();
-  //set control register 
+  // set control register
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_ID);
@@ -122,14 +122,14 @@ unsigned char SPIFlash::flash_read_status(void)
 {
   unsigned char c;
 
-// This can't do a write_pause
+  // This can't do a write_pause
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
-  digitalWrite(_csPin, LOW);  
+  digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_STATUS_REG);
   c = SPI.transfer(0x00);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
-  return(c);
+  return (c);
 }
 
 //=====================================
@@ -143,11 +143,11 @@ void SPIFlash::flash_hard_reset(void)
   // but the library does not support suspend
   // mode yet anyway
   write_pause();
-  
+
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
-  SPI.transfer(CMD_RESET_DEVICE );
+  SPI.transfer(CMD_RESET_DEVICE);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
   delayMicroseconds(50);
@@ -187,13 +187,13 @@ void SPIFlash::flash_erase_pages_sector(int pn)
 {
   int address;
 
-  write_pause(); 
+  write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_WRITE_ENABLE);
   digitalWrite(_csPin, HIGH);
-  
+
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_SECTOR_ERASE);
   // Send the 3 byte address
@@ -202,7 +202,7 @@ void SPIFlash::flash_erase_pages_sector(int pn)
   SPI.transfer((address >> 8) & 0xff);
   SPI.transfer(address & 0xff);
   digitalWrite(_csPin, HIGH);
-  SPI.endTransaction();  
+  SPI.endTransaction();
   // Indicate that next I/O must wait for this write to finish
   flash_wait_for_write = 1;
 }
@@ -239,7 +239,7 @@ void SPIFlash::flash_erase_pages_block32k(int pn)
 void SPIFlash::flash_erase_pages_block64k(int pn)
 {
   int address;
-  
+
   write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
@@ -264,14 +264,14 @@ void SPIFlash::flash_page_program(unsigned char *wp, int pn)
 {
   int address;
 
-  write_pause(); 
+  write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_WRITE_ENABLE);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
-  
+
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_PAGE_PROGRAM);
@@ -282,7 +282,7 @@ void SPIFlash::flash_page_program(unsigned char *wp, int pn)
   SPI.transfer(address & 0xFF);
   // Now write 256 bytes to the page
   for(uint16_t i = 0; i < 256; i++) {
-  SPI.transfer(*wp++);
+    SPI.transfer(*wp++);
   }
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
@@ -291,11 +291,11 @@ void SPIFlash::flash_page_program(unsigned char *wp, int pn)
 }
 
 //=====================================
-void SPIFlash::flash_read_pages(unsigned char *p,int pn,const int n_pages)
+void SPIFlash::flash_read_pages(unsigned char *p, int pn, const int n_pages)
 {
   int address;
   unsigned char *rp = p;
-  
+
   write_pause();
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
@@ -315,14 +315,14 @@ void SPIFlash::flash_read_pages(unsigned char *p,int pn,const int n_pages)
 
 //=====================================
 // Read specified number of pages starting with pn
-void SPIFlash::flash_fast_read_pages(unsigned char *p,int pn,const int n_pages)
+void SPIFlash::flash_fast_read_pages(unsigned char *p, int pn, const int n_pages)
 {
   int address;
   unsigned char *rp = p;
-  
+
   write_pause();
-// The chip doesn't run at the higher clock speed until
-// after the command and address have been sent
+  // The chip doesn't run at the higher clock speed until
+  // after the command and address have been sent
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_HIGH_SPEED);

--- a/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.h
@@ -36,28 +36,28 @@ Sketch based on the work of Pete (El Supremo) as follows:
 #define STAT_WIP 1
 #define STAT_WEL 2
 
-#define CMD_WRITE_STATUS_REG   0x01
-#define CMD_PAGE_PROGRAM       0x02
-#define CMD_READ_DATA          0x03
-#define CMD_WRITE_DISABLE      0x04 
-#define CMD_READ_STATUS_REG    0x05
-#define CMD_WRITE_ENABLE       0x06
-#define CMD_READ_HIGH_SPEED    0x0B 
-#define CMD_SECTOR_ERASE       0x20 
-#define CMD_BLOCK32K_ERASE     0x52 
-#define CMD_RESET_DEVICE       0xF0 
-#define CMD_READ_ID            0x9F
-#define CMD_RELEASE_POWER_DOWN 0xAB 
-#define CMD_POWER_DOWN         0xB9 
-#define CMD_CHIP_ERASE         0xC7
-#define CMD_BLOCK64K_ERASE     0xD8 
+#define CMD_WRITE_STATUS_REG 0x01
+#define CMD_PAGE_PROGRAM 0x02
+#define CMD_READ_DATA 0x03
+#define CMD_WRITE_DISABLE 0x04
+#define CMD_READ_STATUS_REG 0x05
+#define CMD_WRITE_ENABLE 0x06
+#define CMD_READ_HIGH_SPEED 0x0B
+#define CMD_SECTOR_ERASE 0x20
+#define CMD_BLOCK32K_ERASE 0x52
+#define CMD_RESET_DEVICE 0xF0
+#define CMD_READ_ID 0x9F
+#define CMD_RELEASE_POWER_DOWN 0xAB
+#define CMD_POWER_DOWN 0xB9
+#define CMD_CHIP_ERASE 0xC7
+#define CMD_BLOCK64K_ERASE 0xD8
 
 class SPIFlash
 {
-  public: 
+public:
   SPIFlash(uint8_t CSPIN);
   void init();
-  void getChipID(uint8_t * dest);
+  void getChipID(uint8_t *dest);
   void powerDown();
   void powerUp();
   void write_pause(void);
@@ -70,11 +70,11 @@ class SPIFlash
   void flash_erase_pages_sector(int pn);
   void flash_erase_pages_block32k(int pn);
   void flash_erase_pages_block64k(int pn);
-  void flash_page_program(unsigned char *wp,int pn);
-  void flash_read_pages(unsigned char *p,int pn,const int n_pages);
-  void flash_fast_read_pages(unsigned char *p,int pn,const int n_pages);
-  private:
-  uint8_t   _csPin;
+  void flash_page_program(unsigned char *wp, int pn);
+  void flash_read_pages(unsigned char *p, int pn, const int n_pages);
+  void flash_fast_read_pages(unsigned char *p, int pn, const int n_pages);
+private:
+  uint8_t _csPin;
   unsigned char flash_wait_for_write = 0;
 };
 

--- a/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.h
+++ b/GasCap/AssetTracker_GasCap_v.02e/SPIFlash.h
@@ -73,6 +73,7 @@ public:
   void flash_page_program(unsigned char *wp, int pn);
   void flash_read_pages(unsigned char *p, int pn, const int n_pages);
   void flash_fast_read_pages(unsigned char *p, int pn, const int n_pages);
+
 private:
   uint8_t _csPin;
   unsigned char flash_wait_for_write = 0;

--- a/GasCap/readSPIFlash_GasCapAssetTracker/SPIFlash.cpp
+++ b/GasCap/readSPIFlash_GasCapAssetTracker/SPIFlash.cpp
@@ -32,9 +32,8 @@ Sketch based on the work of Pete (El Supremo) as follows:
 
 SPIFlash::SPIFlash(uint8_t CSPIN)
 {
-  _csPin = CSPIN; 
+  _csPin = CSPIN;
 }
-
 
 void SPIFlash::init()
 {
@@ -51,9 +50,8 @@ void SPIFlash::powerUp()
   SPI.endTransaction();
 }
 
-
 void SPIFlash::getChipID()
-{ 
+{
   Serial.print("ID bytes: ");
   uint16_t id[3];
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
@@ -64,7 +62,11 @@ void SPIFlash::getChipID()
   id[2] = SPI.transfer(0);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
-  Serial.print(id[0], HEX); Serial.print(" "); Serial.print(id[1], HEX);  Serial.print(" ");  Serial.println(id[2], HEX); 
+  Serial.print(id[0], HEX);
+  Serial.print(" ");
+  Serial.print(id[1], HEX);
+  Serial.print(" ");
+  Serial.println(id[2], HEX);
 
   Serial.println("Winbond  W25Q80BLUX1G   Chip ID = 0xEF, 0x40, 0x14, 0x0");
   Serial.println("Macronix MX25L12835FZNI Chip ID = 0xC2, 0x20, 0x18, 0xC2");
@@ -72,11 +74,12 @@ void SPIFlash::getChipID()
   Serial.println(" ");
 }
 
-
 void SPIFlash::write_pause(void)
 {
-  if(flash_wait_for_write) {
-    while(flash_read_status() & STAT_WIP);
+  if (flash_wait_for_write)
+  {
+    while (flash_read_status() & STAT_WIP)
+      ;
     flash_wait_for_write = 0;
   }
 }
@@ -85,25 +88,26 @@ void SPIFlash::write_pause(void)
 // convert a page number to a 24-bit address
 int SPIFlash::page_to_address(int pn)
 {
-  return(pn << 8);
+  return (pn << 8);
 }
 
 //=====================================
 // convert a 24-bit address to a page number
 int SPIFlash::address_to_page(int addr)
 {
-  return(addr >> 8);
+  return (addr >> 8);
 }
 
 //=====================================
 void SPIFlash::flash_read_id(unsigned char *idt)
 {
   write_pause();
-  //set control register 
+  // set control register
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_ID);
-  for(uint16_t i = 0; i < 20; i++) {
+  for (uint16_t i = 0; i < 20; i++)
+  {
     *idt++ = SPI.transfer(0x00);
   }
   digitalWrite(_csPin, HIGH);
@@ -115,14 +119,14 @@ unsigned char SPIFlash::flash_read_status(void)
 {
   unsigned char c;
 
-// This can't do a write_pause
+  // This can't do a write_pause
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
-  digitalWrite(_csPin, LOW);  
+  digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_STATUS_REG);
   c = SPI.transfer(0x00);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
-  return(c);
+  return (c);
 }
 
 //=====================================
@@ -136,17 +140,18 @@ void SPIFlash::flash_hard_reset(void)
   // but the library does not support suspend
   // mode yet anyway
   write_pause();
-  
+
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
-  SPI.transfer(CMD_RESET_DEVICE );
+  SPI.transfer(CMD_RESET_DEVICE);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
   delayMicroseconds(50);
   // Wait for the hard reset to finish
   // Don't use flash_wait_for_write here
-  while(flash_read_status() & STAT_WIP);
+  while (flash_read_status() & STAT_WIP)
+    ;
   // The spec says "the device will take
   // approximately tRST=30 microseconds
   // to reset"
@@ -166,7 +171,8 @@ void SPIFlash::flash_chip_erase(boolean wait)
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
   flash_wait_for_write = 1;
-  if(wait)write_pause();
+  if (wait)
+    write_pause();
 }
 
 //=====================================
@@ -180,13 +186,13 @@ void SPIFlash::flash_erase_pages_sector(int pn)
 {
   int address;
 
-  write_pause(); 
+  write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_WRITE_ENABLE);
   digitalWrite(_csPin, HIGH);
-  
+
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_SECTOR_ERASE);
   // Send the 3 byte address
@@ -195,7 +201,7 @@ void SPIFlash::flash_erase_pages_sector(int pn)
   SPI.transfer((address >> 8) & 0xff);
   SPI.transfer(address & 0xff);
   digitalWrite(_csPin, HIGH);
-  SPI.endTransaction();  
+  SPI.endTransaction();
   // Indicate that next I/O must wait for this write to finish
   flash_wait_for_write = 1;
 }
@@ -232,7 +238,7 @@ void SPIFlash::flash_erase_pages_block32k(int pn)
 void SPIFlash::flash_erase_pages_block64k(int pn)
 {
   int address;
-  
+
   write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
@@ -253,18 +259,18 @@ void SPIFlash::flash_erase_pages_block64k(int pn)
 }
 
 //=====================================
-void SPIFlash::flash_page_program(unsigned char *wp,int pn)
+void SPIFlash::flash_page_program(unsigned char *wp, int pn)
 {
   int address;
 
-  write_pause(); 
+  write_pause();
   // Send Write Enable command
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_WRITE_ENABLE);
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
-  
+
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_PAGE_PROGRAM);
@@ -274,8 +280,9 @@ void SPIFlash::flash_page_program(unsigned char *wp,int pn)
   SPI.transfer((address >> 8) & 0xFF);
   SPI.transfer(address & 0xFF);
   // Now write 256 bytes to the page
-  for(uint16_t i = 0; i < 256; i++) {
-  SPI.transfer(*wp++);
+  for (uint16_t i = 0; i < 256; i++)
+  {
+    SPI.transfer(*wp++);
   }
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
@@ -284,11 +291,11 @@ void SPIFlash::flash_page_program(unsigned char *wp,int pn)
 }
 
 //=====================================
-void SPIFlash::flash_read_pages(unsigned char *p,int pn,const int n_pages)
+void SPIFlash::flash_read_pages(unsigned char *p, int pn, const int n_pages)
 {
   int address;
   unsigned char *rp = p;
-  
+
   write_pause();
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
@@ -299,7 +306,8 @@ void SPIFlash::flash_read_pages(unsigned char *p,int pn,const int n_pages)
   SPI.transfer((address >> 8) & 0xFF);
   SPI.transfer(address & 0xFF);
   // Now read the page's data bytes
-  for(uint16_t i = 0; i < n_pages * 256; i++) {
+  for (uint16_t i = 0; i < n_pages * 256; i++)
+  {
     *rp++ = SPI.transfer(0);
   }
   digitalWrite(_csPin, HIGH);
@@ -308,14 +316,14 @@ void SPIFlash::flash_read_pages(unsigned char *p,int pn,const int n_pages)
 
 //=====================================
 // Read specified number of pages starting with pn
-void SPIFlash::flash_fast_read_pages(unsigned char *p,int pn,const int n_pages)
+void SPIFlash::flash_fast_read_pages(unsigned char *p, int pn, const int n_pages)
 {
   int address;
   unsigned char *rp = p;
-  
+
   write_pause();
-// The chip doesn't run at the higher clock speed until
-// after the command and address have been sent
+  // The chip doesn't run at the higher clock speed until
+  // after the command and address have been sent
   SPI.beginTransaction(SPISettings(50000000, MSBFIRST, SPI_MODE0));
   digitalWrite(_csPin, LOW);
   SPI.transfer(CMD_READ_HIGH_SPEED);
@@ -327,7 +335,8 @@ void SPIFlash::flash_fast_read_pages(unsigned char *p,int pn,const int n_pages)
   // send dummy byte
   SPI.transfer(0);
   // Now read the number of pages required
-  for(uint16_t i = 0; i < n_pages * 256; i++) {
+  for (uint16_t i = 0; i < n_pages * 256; i++)
+  {
     *rp++ = SPI.transfer(0);
   }
   digitalWrite(_csPin, HIGH);

--- a/GasCap/readSPIFlash_GasCapAssetTracker/SPIFlash.h
+++ b/GasCap/readSPIFlash_GasCapAssetTracker/SPIFlash.h
@@ -36,25 +36,25 @@ Sketch based on the work of Pete (El Supremo) as follows:
 #define STAT_WIP 1
 #define STAT_WEL 2
 
-#define CMD_WRITE_STATUS_REG   0x01
-#define CMD_PAGE_PROGRAM       0x02
-#define CMD_READ_DATA          0x03
-#define CMD_WRITE_DISABLE      0x04 
-#define CMD_READ_STATUS_REG    0x05
-#define CMD_WRITE_ENABLE       0x06
-#define CMD_READ_HIGH_SPEED    0x0B 
-#define CMD_SECTOR_ERASE       0x20 
-#define CMD_BLOCK32K_ERASE     0x52 
-#define CMD_RESET_DEVICE       0xF0 
-#define CMD_READ_ID            0x9F
-#define CMD_RELEASE_POWER_DOWN 0xAB 
-#define CMD_POWER_DOWN         0xB9 
-#define CMD_CHIP_ERASE         0xC7
-#define CMD_BLOCK64K_ERASE     0xD8 
+#define CMD_WRITE_STATUS_REG 0x01
+#define CMD_PAGE_PROGRAM 0x02
+#define CMD_READ_DATA 0x03
+#define CMD_WRITE_DISABLE 0x04
+#define CMD_READ_STATUS_REG 0x05
+#define CMD_WRITE_ENABLE 0x06
+#define CMD_READ_HIGH_SPEED 0x0B
+#define CMD_SECTOR_ERASE 0x20
+#define CMD_BLOCK32K_ERASE 0x52
+#define CMD_RESET_DEVICE 0xF0
+#define CMD_READ_ID 0x9F
+#define CMD_RELEASE_POWER_DOWN 0xAB
+#define CMD_POWER_DOWN 0xB9
+#define CMD_CHIP_ERASE 0xC7
+#define CMD_BLOCK64K_ERASE 0xD8
 
 class SPIFlash
 {
-  public: 
+public:
   SPIFlash(uint8_t CSPIN);
   void init();
   void powerUp();
@@ -69,11 +69,12 @@ class SPIFlash
   void flash_erase_pages_sector(int pn);
   void flash_erase_pages_block32k(int pn);
   void flash_erase_pages_block64k(int pn);
-  void flash_page_program(unsigned char *wp,int pn);
-  void flash_read_pages(unsigned char *p,int pn,const int n_pages);
-  void flash_fast_read_pages(unsigned char *p,int pn,const int n_pages);
-  private:
-  uint8_t   _csPin;
+  void flash_page_program(unsigned char *wp, int pn);
+  void flash_read_pages(unsigned char *p, int pn, const int n_pages);
+  void flash_fast_read_pages(unsigned char *p, int pn, const int n_pages);
+
+private:
+  uint8_t _csPin;
   unsigned char flash_wait_for_write = 0;
 };
 

--- a/GasCap/readSPIFlash_GasCapAssetTracker/readSPIFlash_GasCapAssetTracker.ino
+++ b/GasCap/readSPIFlash_GasCapAssetTracker/readSPIFlash_GasCapAssetTracker.ino
@@ -38,25 +38,25 @@ uint16_t page_number = 0;
 uint8_t sector_number = 0;
 uint8_t buffer[4] = {0, 0, 0, 0};
 
-uint32_t compHumidity, compTemp, compPress;   // pressure, humidity, and temperature raw count output for BME280
+uint32_t compHumidity, compTemp, compPress;                       // pressure, humidity, and temperature raw count output for BME280
 float temperature_C, temperature_F, pressure, humidity, altitude; // Scaled output of the BME280
 uint8_t second, minute, hour, day, month, year;
 uint16_t rawVbat;
-float  VBAT;
+float VBAT;
 uint16_t gpsAlt;
-float latitude, longitude;   // Stores CAM M8Q GPS position output
-int16_t accelCount[3];       // Stores the 16-bit signed accelerometer sensor output
-int16_t tempCount;           // accel temperature raw count output
-float   temperature;         // Stores the accel temperature in degrees Celsius
-float ax, ay, az;            // variables to hold accel data values 
-float aRes = 0.000244f;      // scale resolutions per LSB for the sensor at 14-bit data 
+float latitude, longitude; // Stores CAM M8Q GPS position output
+int16_t accelCount[3];     // Stores the 16-bit signed accelerometer sensor output
+int16_t tempCount;         // accel temperature raw count output
+float temperature;         // Stores the accel temperature in degrees Celsius
+float ax, ay, az;          // variables to hold accel data values
+float aRes = 0.000244f;    // scale resolutions per LSB for the sensor at 14-bit data
 
 #define csPin 25
 
 SPIFlash SPIFlash(csPin);
 
 void setup(void)
-{ 
+{
   Serial.begin(115200);
   delay(4000);
   Serial.println("Serial enabled!");
@@ -68,105 +68,150 @@ void setup(void)
   SPIFlash.init();
   SPIFlash.powerUp();
   SPIFlash.getChipID();
- 
+
   // read Sensor Tile SPI flash
-  for(page_number = 0; page_number < 10; page_number++)  {
+  for (page_number = 0; page_number < 10; page_number++)
+  {
 
-   //  Serial.print("Read Page 0x"); Serial.println(page_number, HEX);
-   SPIFlash.flash_read_pages(flashPage, page_number, 1);
-      
-   for(sector_number = 0; sector_number < 7; sector_number++) {
-    
-    // reconstruct latitude
-    buffer[0] = flashPage[sector_number*bps + 0];
-    buffer[1] = flashPage[sector_number*bps + 1];
-    buffer[2] = flashPage[sector_number*bps + 2];
-    buffer[3] = flashPage[sector_number*bps + 3];
+    //  Serial.print("Read Page 0x"); Serial.println(page_number, HEX);
+    SPIFlash.flash_read_pages(flashPage, page_number, 1);
 
-    latitude = (float) ( (int32_t) (buffer[0] << 24) | (int32_t) (buffer[1] << 16) | (int32_t) (buffer[2] << 8) | (int32_t) buffer[4]);
-    latitude /= 10000000.0f;
-    
-    // reconstruct longitude
-    buffer[0] = flashPage[sector_number*bps + 4];
-    buffer[1] = flashPage[sector_number*bps + 5];
-    buffer[2] = flashPage[sector_number*bps + 6];
-    buffer[3] = flashPage[sector_number*bps + 7];
+    for (sector_number = 0; sector_number < 7; sector_number++)
+    {
 
-    longitude = (float) ( (int32_t) (buffer[0] << 24) | (int32_t) (buffer[1] << 16) | (int32_t) (buffer[2] << 8) | (int32_t) buffer[4]);
-    longitude /= 10000000.0f;
+      // reconstruct latitude
+      buffer[0] = flashPage[sector_number * bps + 0];
+      buffer[1] = flashPage[sector_number * bps + 1];
+      buffer[2] = flashPage[sector_number * bps + 2];
+      buffer[3] = flashPage[sector_number * bps + 3];
 
-    accelCount[0] = ((int16_t) flashPage[sector_number*bps + 10] << 8) |  flashPage[sector_number*bps + 11];
-    accelCount[1] = ((int16_t) flashPage[sector_number*bps + 12] << 8) |  flashPage[sector_number*bps + 13];
-    accelCount[2] = ((int16_t) flashPage[sector_number*bps + 14] << 8) |  flashPage[sector_number*bps + 15];
-    tempCount =    (int16_t) (((int16_t) flashPage[sector_number*bps + 16] << 8) |  0x00) >> 8;
-    ax = (float)accelCount[0]*aRes;  // get actual g value, this depends on scale being set
-    ay = (float)accelCount[1]*aRes;   
-    az = (float)accelCount[2]*aRes; 
-    temperature =  ((float) tempCount) + 25.0f; // 8-bit accel chip temperature in degrees Centigrade
+      latitude = (float)((int32_t)(buffer[0] << 24) | (int32_t)(buffer[1] << 16) | (int32_t)(buffer[2] << 8) | (int32_t)buffer[4]);
+      latitude /= 10000000.0f;
 
-    // reconstruct temperature
-    buffer[0] = flashPage[sector_number*bps + 16];
-    buffer[1] = flashPage[sector_number*bps + 17];
-    buffer[2] = flashPage[sector_number*bps + 18];
-    buffer[3] = flashPage[sector_number*bps + 19];
+      // reconstruct longitude
+      buffer[0] = flashPage[sector_number * bps + 4];
+      buffer[1] = flashPage[sector_number * bps + 5];
+      buffer[2] = flashPage[sector_number * bps + 6];
+      buffer[3] = flashPage[sector_number * bps + 7];
 
-    temperature_C = (float) ( (int32_t) (buffer[0] << 24) | (int32_t) (buffer[1] << 16) | (int32_t) (buffer[2] << 8) | (int32_t) buffer[4]);
-    temperature_C /= 100.0f; // temperature in degree Centigrade
-    
-    // reconstruct humidity
-    buffer[0] = flashPage[sector_number*bps + 20];
-    buffer[1] = flashPage[sector_number*bps + 21];
-    buffer[2] = flashPage[sector_number*bps + 22];
-    buffer[3] = flashPage[sector_number*bps + 23];
+      longitude = (float)((int32_t)(buffer[0] << 24) | (int32_t)(buffer[1] << 16) | (int32_t)(buffer[2] << 8) | (int32_t)buffer[4]);
+      longitude /= 10000000.0f;
 
-    humidity = (float) ( (int32_t) (buffer[0] << 24) | (int32_t) (buffer[1] << 16) | (int32_t) (buffer[2] << 8) | (int32_t) buffer[4]);
-    humidity /= 1024.0f; // humidity on %rH
-    
-    // reconstruct pressure
-    buffer[0] = flashPage[sector_number*bps + 24];
-    buffer[1] = flashPage[sector_number*bps + 25];
-    buffer[2] = flashPage[sector_number*bps + 26];
-    buffer[3] = flashPage[sector_number*bps + 27];
+      accelCount[0] = ((int16_t)flashPage[sector_number * bps + 10] << 8) | flashPage[sector_number * bps + 11];
+      accelCount[1] = ((int16_t)flashPage[sector_number * bps + 12] << 8) | flashPage[sector_number * bps + 13];
+      accelCount[2] = ((int16_t)flashPage[sector_number * bps + 14] << 8) | flashPage[sector_number * bps + 15];
+      tempCount = (int16_t)(((int16_t)flashPage[sector_number * bps + 16] << 8) | 0x00) >> 8;
+      ax = (float)accelCount[0] * aRes; // get actual g value, this depends on scale being set
+      ay = (float)accelCount[1] * aRes;
+      az = (float)accelCount[2] * aRes;
+      temperature = ((float)tempCount) + 25.0f; // 8-bit accel chip temperature in degrees Centigrade
 
-    pressure = (float) ( (int32_t) (buffer[0] << 24) | (int32_t) (buffer[1] << 16) | (int32_t) (buffer[2] << 8) | (int32_t) buffer[4]);
-    pressure /= 25600.0f;  // pressure in millibars
+      // reconstruct temperature
+      buffer[0] = flashPage[sector_number * bps + 16];
+      buffer[1] = flashPage[sector_number * bps + 17];
+      buffer[2] = flashPage[sector_number * bps + 18];
+      buffer[3] = flashPage[sector_number * bps + 19];
 
-    second =  flashPage[sector_number*bps + 28];
-    minute =  flashPage[sector_number*bps + 29];
-    hour =    flashPage[sector_number*bps + 30];
-    day =     flashPage[sector_number*bps + 31];
-    month =   flashPage[sector_number*bps + 32];
-    year =    flashPage[sector_number*bps + 33];
+      temperature_C = (float)((int32_t)(buffer[0] << 24) | (int32_t)(buffer[1] << 16) | (int32_t)(buffer[2] << 8) | (int32_t)buffer[4]);
+      temperature_C /= 100.0f; // temperature in degree Centigrade
 
-    gpsAlt = ((uint16_t) flashPage[sector_number*bps + 8] << 8) |  flashPage[sector_number*bps + 9];
-    
-    rawVbat = ((uint16_t) flashPage[sector_number*bps + 34] << 8) |  flashPage[sector_number*bps + 35];
+      // reconstruct humidity
+      buffer[0] = flashPage[sector_number * bps + 20];
+      buffer[1] = flashPage[sector_number * bps + 21];
+      buffer[2] = flashPage[sector_number * bps + 22];
+      buffer[3] = flashPage[sector_number * bps + 23];
 
-    gpsAlt *= 3.2808399f/10.0f;
+      humidity = (float)((int32_t)(buffer[0] << 24) | (int32_t)(buffer[1] << 16) | (int32_t)(buffer[2] << 8) | (int32_t)buffer[4]);
+      humidity /= 1024.0f; // humidity on %rH
 
-    VBAT = rawVbat/100.0f;
+      // reconstruct pressure
+      buffer[0] = flashPage[sector_number * bps + 24];
+      buffer[1] = flashPage[sector_number * bps + 25];
+      buffer[2] = flashPage[sector_number * bps + 26];
+      buffer[3] = flashPage[sector_number * bps + 27];
 
-    // Output for spreadsheet analysis
-    if(month < 10) {Serial.print("0"); Serial.print(month);} else Serial.print(month);
-    Serial.print("/");Serial.print(day); Serial.print("/");Serial.print(year); Serial.print(" ");
-    if(hour < 10) {Serial.print("0"); Serial.print(hour);} else Serial.print(hour);
-    Serial.print(":"); 
-    if(minute < 10) {Serial.print("0"); Serial.print(minute);} else Serial.print(minute); 
-    Serial.print(":"); 
-    if(second < 10) {Serial.print("0"); Serial.print(second);} else Serial.print(second); Serial.print(",");  
-        
-    Serial.print(pressure, 2); Serial.print(","); Serial.print(temperature_C, 2); Serial.print(",");Serial.print(humidity, 2); Serial.print(","); 
-    
-    Serial.print(latitude, 7); Serial.print(","); Serial.print(longitude, 7); Serial.print(","); Serial.print(gpsAlt, 1);  Serial.print(","); 
-    
-    Serial.print((int)1000*ax); Serial.print(","); Serial.print((int)1000*ay); Serial.print(","); Serial.print((int)1000*az); Serial.print(","); 
-    
-    Serial.print(temperature, 1); Serial.print(","); Serial.println(VBAT, 2);    
+      pressure = (float)((int32_t)(buffer[0] << 24) | (int32_t)(buffer[1] << 16) | (int32_t)(buffer[2] << 8) | (int32_t)buffer[4]);
+      pressure /= 25600.0f; // pressure in millibars
+
+      second = flashPage[sector_number * bps + 28];
+      minute = flashPage[sector_number * bps + 29];
+      hour = flashPage[sector_number * bps + 30];
+      day = flashPage[sector_number * bps + 31];
+      month = flashPage[sector_number * bps + 32];
+      year = flashPage[sector_number * bps + 33];
+
+      gpsAlt = ((uint16_t)flashPage[sector_number * bps + 8] << 8) | flashPage[sector_number * bps + 9];
+
+      rawVbat = ((uint16_t)flashPage[sector_number * bps + 34] << 8) | flashPage[sector_number * bps + 35];
+
+      gpsAlt *= 3.2808399f / 10.0f;
+
+      VBAT = rawVbat / 100.0f;
+
+      // Output for spreadsheet analysis
+      if (month < 10)
+      {
+        Serial.print("0");
+        Serial.print(month);
+      }
+      else
+        Serial.print(month);
+      Serial.print("/");
+      Serial.print(day);
+      Serial.print("/");
+      Serial.print(year);
+      Serial.print(" ");
+      if (hour < 10)
+      {
+        Serial.print("0");
+        Serial.print(hour);
+      }
+      else
+        Serial.print(hour);
+      Serial.print(":");
+      if (minute < 10)
+      {
+        Serial.print("0");
+        Serial.print(minute);
+      }
+      else
+        Serial.print(minute);
+      Serial.print(":");
+      if (second < 10)
+      {
+        Serial.print("0");
+        Serial.print(second);
+      }
+      else
+        Serial.print(second);
+      Serial.print(",");
+
+      Serial.print(pressure, 2);
+      Serial.print(",");
+      Serial.print(temperature_C, 2);
+      Serial.print(",");
+      Serial.print(humidity, 2);
+      Serial.print(",");
+
+      Serial.print(latitude, 7);
+      Serial.print(",");
+      Serial.print(longitude, 7);
+      Serial.print(",");
+      Serial.print(gpsAlt, 1);
+      Serial.print(",");
+
+      Serial.print((int)1000 * ax);
+      Serial.print(",");
+      Serial.print((int)1000 * ay);
+      Serial.print(",");
+      Serial.print((int)1000 * az);
+      Serial.print(",");
+
+      Serial.print(temperature, 1);
+      Serial.print(",");
+      Serial.println(VBAT, 2);
     }
-  
   }
-
-
 }
 
 void loop(void)


### PR DESCRIPTION
There were some areas where the indentation wasn't quite right so VSCode's automatic indentation was used to automate some of the formatting. I rolled back some of the changes where it made sense (keeping some print statements all in one line), but now for the GasCap folder the indentation should be 100% correct. 

It wouldn't build because some of the include statements referenced I2CDev.h (upper-case d) and the file was named I2Cdev.h (lower-case d), now those match.

There were some instances of I2Cdev.h being referenced by both a cpp file and its header. Now it's just being referenced in the header.

Since this PR is almost entirely whitespace changes my only validation test was to build. I use the arduino command-line tool, so the build command was

```
cd GasCap/AssetTracker_GasCap_v.02e/
arduino-cli compile --export-binaries --fqbn TleraCorp:stm32l0:Cricket-L082CZ
```
Which compiled as expected. 